### PR TITLE
fix(core/list): pass `getKey` to `useList`

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -223,7 +223,7 @@ const Items: React.FC = list({
   mapItem: {
     propName: (item: Item, index: number) => propValue, // maps array store item to View props
   },
-  getKey: (item: Item, index: number) => React.Key // optional, will use index by default
+  getKey: (item: Item) => React.Key // optional, will use index by default
 });
 ```
 
@@ -236,7 +236,7 @@ Method creates component, which renders list of `view` components based on items
 1. `mapItem` — Object `{ propName: (Item, index) => propValue }` that defines rules, by which every `Item` will be mapped to props of each rendered list item.
 1. `bind` — Optional object of stores, events, and static values that will be bound as props to every list item.
 1. `hooks` — Optional object `{ mounted, unmounted }` to handle when any list item component is mounted or unmounted.
-1. `getKey` - Optional function `(item: Item, index: number) => React.Key` to set key for every item in the list to help React with effecient rerenders. If not provided, index is used
+1. `getKey` - Optional function `(item: Item) => React.Key` to set key for every item in the list to help React with effecient rerenders. If not provided, index is used. See [`effector-react`](https://effector.dev/docs/api/effector-react/useList) docs for more details.
 
 
 #### Returns

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@types/react-dom": "^16.9.0",
     "@typescript-eslint/parser": "^4.8.1",
     "effector": "^21.8.3",
-    "effector-react": "^21.2.0",
+    "effector-react": "^21.3.0",
     "eslint": "^7.14.0",
     "fs-extra": "^9.0.1",
     "husky": "^4.3.0",
@@ -59,7 +59,7 @@
   },
   "peerDependencies": {
     "effector": "^21.8.0",
-    "effector-react": "^21.2.0",
+    "effector-react": "^21.3.0",
     "react": "^16.14.0 || ^17.0.0"
   },
   "husky": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2337,10 +2337,10 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
-effector-react@^21.2.0:
-  version "21.2.0"
-  resolved "https://registry.yarnpkg.com/effector-react/-/effector-react-21.2.0.tgz#c15e2ef59e27b7772704168a59acee0808f3ab41"
-  integrity sha512-lAz8b2F5YgfJKQIegbBT2w8Jqvcs+62QnnYJe4+PqI2s7X3oJvuQ2Zm1obrrsWpoMOqDUdEpaP0KDMq8YRg5ng==
+effector-react@^21.3.0:
+  version "21.3.0"
+  resolved "https://registry.yarnpkg.com/effector-react/-/effector-react-21.3.0.tgz#44a94355930aae25a386c039c6397091e2408e71"
+  integrity sha512-BnTxHUq1OcW7MwM67Fs43DbV3lcXlrhEyqcIUbMZPDkK6KTOz4nzHO1kP14bGQ7k+7nVeTV8xLCVGfmiZmNSkQ==
 
 effector@^21.8.3:
   version "21.8.3"


### PR DESCRIPTION
Yesterday effector-react@21.3.0 was released and this version supports getKey in useList, so no reason to create this key manually - just passing `getKey` to `useList` config now