### PR TITLE
Add tests for `getKey` option in `list`

### DIFF
--- a/src/no-ssr/list.test.tsx
+++ b/src/no-ssr/list.test.tsx
@@ -1,5 +1,6 @@
-import React, { FC } from 'react';
+import React, { FC, memo } from 'react';
 import { createStore, createEvent } from 'effector';
+import { useStore } from 'effector-react';
 
 import { render } from '@testing-library/react';
 import { act } from 'react-dom/test-utils';
@@ -188,4 +189,99 @@ test('reflect-list: reflect binds props to every item in the list', async () => 
   expect(
     container.getAllByRole('listitem').map((item) => item.dataset.prefix),
   ).toEqual($todos.getState().map(() => $prefix.getState()));
+});
+
+interface MemberProps {
+  id: number;
+  name: string;
+}
+
+const Member: FC<MemberProps> = (props) => {
+  const { name, id } = props;
+
+  return <li data-testid={id}>{name}</li>;
+};
+
+test('reflect-list: getKey option', async () => {
+  const fn = jest.fn();
+  const fn2 = jest.fn();
+  const renameUser = createEvent<{ id: number; name: string }>();
+  const removeUser = createEvent<number>();
+  const sortById = createEvent();
+  const $members = createStore([
+    { name: 'alice', id: 1 },
+    { name: 'bob', id: 3 },
+    { name: 'carol', id: 2 },
+  ])
+    .on(renameUser, (list, { id, name }) =>
+      list.map((e) => (e.id === id ? { id, name } : e)),
+    )
+    .on(removeUser, (list, id) => list.filter((e) => e.id !== id))
+    .on(sortById, (list) => [...list].sort((a, b) => a.id - b.id));
+
+  // plain
+  const PlainMember = memo((props: MemberProps) => {
+    fn2(props);
+    return <Member id={props.id} name={props.name} />;
+  });
+
+  const PlainMemberList = () => {
+    return (
+      <ul data-list="plain">
+        {useStore($members).map((props) => (
+          <PlainMember key={props.id} id={props.id} name={props.name} />
+        ))}
+      </ul>
+    );
+  };
+
+  // reflect
+  const ReflectMember: FC<MemberProps> = (props) => {
+    fn(props);
+    return <Member id={props.id} name={props.name} />;
+  };
+  const ReflectList: FC = (props) => (
+    <ul data-list="reflect">{props.children}</ul>
+  );
+  const Members = list({
+    source: $members,
+    view: ReflectMember,
+    bind: {},
+    mapItem: {
+      id: (member) => member.id,
+      name: (member) => member.name,
+    },
+    getKey: (item) => item.id,
+  });
+
+  const App = () => (
+    <>
+      <PlainMemberList />
+      <ReflectList>
+        <Members />
+      </ReflectList>
+    </>
+  );
+
+  const container = render(<App />);
+
+  // first check
+
+  act(() => {
+    sortById();
+  });
+
+  // second check
+
+  act(() => {
+    renameUser({ id: 2, name: 'charlie' });
+  });
+
+  // third check
+
+  act(() => {
+    removeUser(2);
+  });
+
+  // last check
 });

--- a/src/no-ssr/list.test.tsx
+++ b/src/no-ssr/list.test.tsx
@@ -227,7 +227,7 @@ test('reflect-list: getKey option', async () => {
 
   const PlainMemberList = () => {
     return (
-      <ul data-list="plain">
+      <ul data-testid="plain">
         {useStore($members).map((props) => (
           <PlainMember key={props.id} id={props.id} name={props.name} />
         ))}
@@ -241,7 +241,7 @@ test('reflect-list: getKey option', async () => {
     return <Member id={props.id} name={props.name} />;
   };
   const ReflectList: FC = (props) => (
-    <ul data-list="reflect">{props.children}</ul>
+    <ul data-testid="reflect">{props.children}</ul>
   );
   const Members = list({
     source: $members,
@@ -266,22 +266,78 @@ test('reflect-list: getKey option', async () => {
   const container = render(<App />);
 
   // first check
+  expect(
+    Array.from(
+      container.getByTestId('plain').querySelectorAll('li'),
+    ).map((item) => Number(item.dataset.testid)),
+  ).toEqual($members.getState().map((member) => member.id));
+  expect(
+    Array.from(
+      container.getByTestId('reflect').querySelectorAll('li'),
+    ).map((item) => Number(item.dataset.testid)),
+  ).toEqual($members.getState().map((member) => member.id));
+
+  expect(fn.mock.calls.map(([arg]) => arg)).toEqual(
+    fn2.mock.calls.map(([arg]) => arg),
+  );
 
   act(() => {
     sortById();
   });
 
   // second check
+  expect(
+    Array.from(
+      container.getByTestId('plain').querySelectorAll('li'),
+    ).map((item) => Number(item.dataset.testid)),
+  ).toEqual($members.getState().map((member) => member.id));
+  expect(
+    Array.from(
+      container.getByTestId('reflect').querySelectorAll('li'),
+    ).map((item) => Number(item.dataset.testid)),
+  ).toEqual($members.getState().map((member) => member.id));
+
+  expect(fn.mock.calls.map(([arg]) => arg)).toEqual(
+    fn2.mock.calls.map(([arg]) => arg),
+  );
 
   act(() => {
     renameUser({ id: 2, name: 'charlie' });
   });
 
   // third check
+  expect(
+    Array.from(
+      container.getByTestId('plain').querySelectorAll('li'),
+    ).map((item) => Number(item.dataset.testid)),
+  ).toEqual($members.getState().map((member) => member.id));
+  expect(
+    Array.from(
+      container.getByTestId('reflect').querySelectorAll('li'),
+    ).map((item) => Number(item.dataset.testid)),
+  ).toEqual($members.getState().map((member) => member.id));
+
+  expect(fn.mock.calls.map(([arg]) => arg)).toEqual(
+    fn2.mock.calls.map(([arg]) => arg),
+  );
 
   act(() => {
     removeUser(2);
   });
 
   // last check
+  expect(
+    Array.from(
+      container.getByTestId('plain').querySelectorAll('li'),
+    ).map((item) => Number(item.dataset.testid)),
+  ).toEqual($members.getState().map((member) => member.id));
+  expect(
+    Array.from(
+      container.getByTestId('reflect').querySelectorAll('li'),
+    ).map((item) => Number(item.dataset.testid)),
+  ).toEqual($members.getState().map((member) => member.id));
+
+  expect(fn.mock.calls.map(([arg]) => arg)).toEqual(
+    fn2.mock.calls.map(([arg]) => arg),
+  );
 });

--- a/src/ssr/list.test.tsx
+++ b/src/ssr/list.test.tsx
@@ -1,6 +1,6 @@
-import React, { FC } from 'react';
+import React, { FC, memo } from 'react';
 import { createDomain, fork, allSettled } from 'effector';
-import { Provider } from 'effector-react/ssr';
+import { Provider, useStore } from 'effector-react/ssr';
 
 import { render, act } from '@testing-library/react';
 
@@ -213,4 +213,159 @@ test('reflect-list: reflect binds props to every item in the list', async () => 
   expect(
     container.getAllByRole('listitem').map((item) => item.dataset.prefix),
   ).toEqual(scope.getState($todos).map(() => scope.getState($prefix)));
+});
+
+interface MemberProps {
+  id: number;
+  name: string;
+}
+
+const Member: FC<MemberProps> = (props) => {
+  const { name, id } = props;
+
+  return <li data-testid={id}>{name}</li>;
+};
+
+test('reflect-list: getKey option', async () => {
+  const fn = jest.fn();
+  const fn2 = jest.fn();
+  const app = createDomain();
+
+  const renameUser = app.createEvent<{ id: number; name: string }>();
+  const removeUser = app.createEvent<number>();
+  const sortById = app.createEvent();
+  const $members = app
+    .createStore([
+      { name: 'alice', id: 1 },
+      { name: 'bob', id: 3 },
+      { name: 'carol', id: 2 },
+    ])
+    .on(renameUser, (list, { id, name }) =>
+      list.map((e) => (e.id === id ? { id, name } : e)),
+    )
+    .on(removeUser, (list, id) => list.filter((e) => e.id !== id))
+    .on(sortById, (list) => [...list].sort((a, b) => a.id - b.id));
+
+  // plain
+  const PlainMember = memo((props: MemberProps) => {
+    fn2(props);
+    return <Member id={props.id} name={props.name} />;
+  });
+
+  const PlainMemberList = () => {
+    return (
+      <ul data-testid="plain">
+        {useStore($members).map((props) => (
+          <PlainMember key={props.id} id={props.id} name={props.name} />
+        ))}
+      </ul>
+    );
+  };
+
+  // reflect
+  const ReflectMember: FC<MemberProps> = (props) => {
+    fn(props);
+    return <Member id={props.id} name={props.name} />;
+  };
+  const ReflectList: FC = (props) => (
+    <ul data-testid="reflect">{props.children}</ul>
+  );
+  const Members = list({
+    source: $members,
+    view: ReflectMember,
+    bind: {},
+    mapItem: {
+      id: (member) => member.id,
+      name: (member) => member.name,
+    },
+    getKey: (item) => item.id,
+  });
+
+  const scope = fork(app);
+  const App = () => (
+    <Provider value={scope}>
+      <PlainMemberList />
+      <ReflectList>
+        <Members />
+      </ReflectList>
+    </Provider>
+  );
+
+  const container = render(<App />);
+
+  // first check
+  expect(
+    Array.from(
+      container.getByTestId('plain').querySelectorAll('li'),
+    ).map((item) => Number(item.dataset.testid)),
+  ).toEqual(scope.getState($members).map((member) => member.id));
+  expect(
+    Array.from(
+      container.getByTestId('reflect').querySelectorAll('li'),
+    ).map((item) => Number(item.dataset.testid)),
+  ).toEqual(scope.getState($members).map((member) => member.id));
+
+  expect(fn.mock.calls.map(([arg]) => arg)).toEqual(
+    fn2.mock.calls.map(([arg]) => arg),
+  );
+
+  await act(async () => {
+    await allSettled(sortById, { scope });
+  });
+
+  // second check
+  expect(
+    Array.from(
+      container.getByTestId('plain').querySelectorAll('li'),
+    ).map((item) => Number(item.dataset.testid)),
+  ).toEqual(scope.getState($members).map((member) => member.id));
+  expect(
+    Array.from(
+      container.getByTestId('reflect').querySelectorAll('li'),
+    ).map((item) => Number(item.dataset.testid)),
+  ).toEqual(scope.getState($members).map((member) => member.id));
+
+  expect(fn.mock.calls.map(([arg]) => arg)).toEqual(
+    fn2.mock.calls.map(([arg]) => arg),
+  );
+
+  await act(async () => {
+    await allSettled(renameUser, { scope, params: { id: 2, name: 'charlie' } });
+  });
+
+  // third check
+  expect(
+    Array.from(
+      container.getByTestId('plain').querySelectorAll('li'),
+    ).map((item) => Number(item.dataset.testid)),
+  ).toEqual(scope.getState($members).map((member) => member.id));
+  expect(
+    Array.from(
+      container.getByTestId('reflect').querySelectorAll('li'),
+    ).map((item) => Number(item.dataset.testid)),
+  ).toEqual(scope.getState($members).map((member) => member.id));
+
+  expect(fn.mock.calls.map(([arg]) => arg)).toEqual(
+    fn2.mock.calls.map(([arg]) => arg),
+  );
+
+  await act(async () => {
+    await allSettled(removeUser, { scope, params: 2 });
+  });
+
+  // last check
+  expect(
+    Array.from(
+      container.getByTestId('plain').querySelectorAll('li'),
+    ).map((item) => Number(item.dataset.testid)),
+  ).toEqual(scope.getState($members).map((member) => member.id));
+  expect(
+    Array.from(
+      container.getByTestId('reflect').querySelectorAll('li'),
+    ).map((item) => Number(item.dataset.testid)),
+  ).toEqual(scope.getState($members).map((member) => member.id));
+
+  expect(fn.mock.calls.map(([arg]) => arg)).toEqual(
+    fn2.mock.calls.map(([arg]) => arg),
+  );
 });


### PR DESCRIPTION
Added tests to ensure that a list component created via `list` with `getKey` option provided will behave the same way that classic plain React list component with `key` props provided would behave