### PR TITLE
move to new effector-react and add react-18 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,7 @@ effector-reflect-*
 core/
 index.*
 ssr.*
+scope.*js
+scope.*map
+scope.d.ts
 reflect.*

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "@typescript-eslint/parser": "^4.8.1",
     "babel-plugin-module-resolver": "^4.1.0",
     "effector": "^22.0.6",
-    "effector-react": "22.1.0",
+    "effector-react": "^22.1.0",
     "eslint": "^7.14.0",
     "fs-extra": "^9.0.1",
     "husky": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,12 @@
       "import": "./ssr.mjs",
       "require": "./ssr.js",
       "default": "./ssr.mjs"
+    },
+    "./scope.mjs": "./scope.mjs",
+    "./scope": {
+      "import": "./scope.mjs",
+      "require": "./scope.js",
+      "default": "./scope.mjs"
     }
   },
   "main": "reflect.cjs.js",
@@ -34,6 +40,7 @@
     "core",
     "index.d.ts",
     "ssr.d.ts",
+    "scope.d.ts",
     "reflect.cjs.js",
     "reflect.cjs.js.map",
     "reflect.mjs",
@@ -41,7 +48,11 @@
     "ssr.js",
     "ssr.js.map",
     "ssr.mjs",
-    "ssr.mjs.map"
+    "ssr.mjs.map",
+    "scope.js",
+    "scope.js.map",
+    "scope.mjs",
+    "scope.mjs.map"
   ],
   "scripts": {
     "test:code": "jest ./src",
@@ -50,7 +61,7 @@
     "test:code:build": "jest ./dist-test",
     "test-build": "yarn test:code:build",
     "build": "yarn clear-build && yarn rollup --config ./rollup.config.js && cp index.d.ts reflect.d.ts",
-    "clear-build": "rm -f index.* && rm -f reflect.* && rm -f ssr.* && rm -rf dist && rm -rf core",
+    "clear-build": "rm -f index.* && rm -f reflect.* && rm -f ssr.* && rm -f scope.* && rm -rf dist && rm -rf core",
     "prepublishOnly": "yarn build"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@typescript-eslint/parser": "^4.8.1",
     "babel-plugin-module-resolver": "^4.1.0",
     "effector": "^22.0.6",
-    "effector-react": "^22.0.4",
+    "effector-react": "22.1.0",
     "eslint": "^7.14.0",
     "fs-extra": "^9.0.1",
     "husky": "^4.3.0",
@@ -92,9 +92,9 @@
     "uglify-es": "^3.3.9"
   },
   "peerDependencies": {
-    "effector": "^21.8.0 || ^22.0.0",
-    "effector-react": "^21.3.0 || ^22.0.0",
-    "react": "^16.14.0 || ^17.0.0"
+    "effector": "^22.0.0",
+    "effector-react": "^22.1.0",
+    "react": ">=16.8.0 <19.0.0"
   },
   "husky": {
     "hooks": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -41,7 +41,7 @@ const plugins = (isEsm) => [
     extensions: ['.js', '.mjs'],
   }),
   commonjs({ extensions: ['.js', '.mjs'] }),
-  terser(),
+  // terser(),
 ];
 
 const noSsr = './src/index.ts';
@@ -54,6 +54,7 @@ const external = [
   'effector-react/effector-react.mjs',
   'react',
   'effector-react/ssr',
+  'effector-react/scope',
 ];
 
 export default [

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -46,6 +46,7 @@ const plugins = (isEsm) => [
 
 const noSsr = './src/index.ts';
 const ssr = './src/ssr.ts';
+const scope = './src/scope.ts';
 const external = [
   'effector',
   'effector/effector.mjs',
@@ -79,6 +80,17 @@ export default [
     },
   },
   {
+    input: scope,
+    external,
+    plugins: plugins(true),
+    output: {
+      file: './scope.mjs',
+      format: 'es',
+      sourcemap: true,
+      externalLiveBindings: false,
+    },
+  },
+  {
     input: noSsr,
     external,
     plugins: plugins(),
@@ -97,6 +109,19 @@ export default [
     plugins: plugins(),
     output: {
       file: './ssr.js',
+      format: 'cjs',
+      freeze: false,
+      exports: 'named',
+      sourcemap: true,
+      externalLiveBindings: false,
+    },
+  },
+  {
+    input: scope,
+    external,
+    plugins: plugins(),
+    output: {
+      file: './scope.js',
       format: 'cjs',
       freeze: false,
       exports: 'named',

--- a/src/core/reflect.ts
+++ b/src/core/reflect.ts
@@ -49,11 +49,11 @@ export function reflectFactory(context: ReflectCreatorContext) {
       }
     }
 
-    const $bind = isEmpty(stores) ? null : combine(stores);
+    const $bind = isEmpty(stores) ? null : stores;
 
     return (props) => {
-      const storeProps = $bind ? context.useStore($bind) : ({} as Props);
-      const eventsProps = context.useEvent(events);
+      const storeProps = $bind ? context.useUnit($bind) : ({} as Props);
+      const eventsProps = context.useUnit(events);
       const elementProps: Props = Object.assign(
         {},
         storeProps,
@@ -83,7 +83,7 @@ function readHook(
 ): (() => void) | void {
   if (hook) {
     if (is.event(hook) || is.effect(hook)) {
-      return context.useEvent(hook as Event<void>);
+      return context.useUnit(hook as Event<void>);
     }
     return hook;
   }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,10 +1,9 @@
 import { FC, ComponentClass } from 'react';
 import { Store, Event, Effect } from 'effector';
-import { useEvent, useList, useStore } from 'effector-react';
+import { useUnit, useList } from 'effector-react';
 
 export interface ReflectCreatorContext {
-  useStore: typeof useStore;
-  useEvent: typeof useEvent;
+  useUnit: typeof useUnit;
   useList: typeof useList;
 }
 

--- a/src/core/variant.ts
+++ b/src/core/variant.ts
@@ -29,7 +29,7 @@ export function variantFactory(context: ReflectCreatorContext) {
     default?: View<Props>;
   }): React.FC<PropsByBind<Props, Bind>> {
     function View(props: Props) {
-      const nameOfCase = context.useStore(config.source);
+      const nameOfCase = context.useUnit(config.source);
       const Component = config.cases[nameOfCase] ?? config.default ?? Default;
 
       return React.createElement(Component, props);

--- a/src/scope.ts
+++ b/src/scope.ts
@@ -1,0 +1,14 @@
+import * as effectorReactSSR from 'effector-react/scope';
+import {
+  variantFactory,
+  reflectCreateFactory,
+  reflectFactory,
+  listFactory,
+} from './core';
+
+export const reflect = reflectFactory(effectorReactSSR);
+export const createReflect = reflectCreateFactory(effectorReactSSR);
+
+export const variant = variantFactory(effectorReactSSR);
+
+export const list = listFactory(effectorReactSSR);

--- a/src/ssr.ts
+++ b/src/ssr.ts
@@ -1,14 +1,4 @@
-import * as effectorReactSSR from 'effector-react/ssr';
-import {
-  variantFactory,
-  reflectCreateFactory,
-  reflectFactory,
-  listFactory,
-} from './core';
-
-export const reflect = reflectFactory(effectorReactSSR);
-export const createReflect = reflectCreateFactory(effectorReactSSR);
-
-export const variant = variantFactory(effectorReactSSR);
-
-export const list = listFactory(effectorReactSSR);
+console.error(
+  '`@effector/reflect/ssr` is deprecated, import from `@effector/reflect/scope` instead',
+);
+export * from './scope';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2442,7 +2442,7 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
-effector-react@22.1.0:
+effector-react@^22.1.0:
   version "22.1.0"
   resolved "https://registry.yarnpkg.com/effector-react/-/effector-react-22.1.0.tgz#698239341193b6fc92b51c5effb9b7110df6ac06"
   integrity sha512-Wm/4tbIVOld0nqaglH+VxlYaxvqmkoKmynNCiEmQ/ekqx2ChieGOcNHMJrOETKZEa4pB9TQf3a9qDnQG5jXPAA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2442,10 +2442,12 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
-effector-react@^22.0.4:
-  version "22.0.4"
-  resolved "https://registry.yarnpkg.com/effector-react/-/effector-react-22.0.4.tgz#4dcefdbf1167a0ad9a23fbabeec03a66a0f746de"
-  integrity sha512-4bWdcUXZlET5uKF/+9HNeB+s7tAPrD6V7RWbTJXeDCVSwF6gXgDQMjmla7DtHsbpZxB6hSsH98JfqFq7yXbXdw==
+effector-react@22.1.0:
+  version "22.1.0"
+  resolved "https://registry.yarnpkg.com/effector-react/-/effector-react-22.1.0.tgz#698239341193b6fc92b51c5effb9b7110df6ac06"
+  integrity sha512-Wm/4tbIVOld0nqaglH+VxlYaxvqmkoKmynNCiEmQ/ekqx2ChieGOcNHMJrOETKZEa4pB9TQf3a9qDnQG5jXPAA==
+  dependencies:
+    use-sync-external-store "^1.0.0"
 
 effector@^22.0.6:
   version "22.0.6"
@@ -6105,6 +6107,11 @@ urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
+
+use-sync-external-store@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
+  integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
Changelog:
- `effector`-21 is not supported anymore
- `effector-react@^22.1.0` is required
- Thanks to `effector-react@^22.1.0` is now supported
- Include `/scope` export
- Deprecate `/ssr` export