### PR TITLE
Add support for force scope

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
   },
   "peerDependencies": {
     "effector": "^22.0.0",
-    "effector-react": "^22.1.0",
+    "effector-react": "^22.3.0",
     "react": ">=16.8.0 <19.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "babel-jest": "^29.4.3",
     "babel-plugin-module-resolver": "^4.1.0",
     "effector": "^22.0.6",
-    "effector-react": "^22.1.0",
+    "effector-react": "^22.3.0",
     "eslint": "^8.22.0",
     "eslint-kit": "^6.11.0",
     "fs-extra": "^9.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,7 +20,7 @@ specifiers:
   babel-jest: ^29.4.3
   babel-plugin-module-resolver: ^4.1.0
   effector: ^22.0.6
-  effector-react: ^22.1.0
+  effector-react: ^22.3.0
   eslint: ^8.22.0
   eslint-kit: ^6.11.0
   fs-extra: ^9.0.1
@@ -59,7 +59,7 @@ devDependencies:
   babel-jest: 29.4.3_@babel+core@7.21.0
   babel-plugin-module-resolver: 4.1.0
   effector: 22.5.2
-  effector-react: 22.5.0_ljphihe53hzzpqkbmewyqqpz6i
+  effector-react: 22.5.1_ljphihe53hzzpqkbmewyqqpz6i
   eslint: 8.22.0
   eslint-kit: 6.11.0_eqcc7dcqpetk7diz5y3u642qiq
   fs-extra: 9.1.0
@@ -3277,8 +3277,8 @@ packages:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
     dev: true
 
-  /effector-react/22.5.0_ljphihe53hzzpqkbmewyqqpz6i:
-    resolution: {integrity: sha512-f9aOWFKr4i6fhdoV1uHa2n89f9+9edmOJL9UhMgjUcs2al3fyh3R5j1WDx0cHU6TuFtrlnFsulbhd2D/8q7reQ==}
+  /effector-react/22.5.1_ljphihe53hzzpqkbmewyqqpz6i:
+    resolution: {integrity: sha512-Sy5b/sUEZoCuyoCr+SiHcgd0L+PQqnIGx+SuPCZ7MhECYxezkkeecsk0EVj9sykLL2qlEeg+rdiWvIATJgOTeA==}
     engines: {node: '>=11.0.0'}
     peerDependencies:
       effector: ^22.0.2

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,3 +1,4 @@
-export { createReflect, reflect } from './reflect';
-export { variant } from './variant';
-export { list } from './list';
+export { reflectFactory, reflectCreateFactory } from './reflect';
+export { variantFactory } from './variant';
+export { listFactory } from './list';
+export type { Context } from './types';

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,3 +1,3 @@
-export { reflectFactory, reflectCreateFactory } from './reflect';
-export { variantFactory } from './variant';
-export { listFactory } from './list';
+export { createReflect, reflect } from './reflect';
+export { variant } from './variant';
+export { list } from './list';

--- a/src/core/list.ts
+++ b/src/core/list.ts
@@ -1,8 +1,9 @@
 import { Store } from 'effector';
+import { useList } from 'effector-react';
 import React from 'react';
 
-import { reflectFactory } from './reflect';
-import { BindableProps, Context, Hooks, PartialBoundProps, View } from './types';
+import { reflect } from './reflect';
+import { BindableProps, Hooks, PartialBoundProps, View } from './types';
 
 type ReflectListConfig<Props, Item, Bind> = Item extends Props
   ? {
@@ -43,50 +44,48 @@ type ReflectListConfig<Props, Item, Bind> = Item extends Props
           };
         };
 
-export function listFactory(context: Context) {
-  const reflect = reflectFactory(context);
+const isClientSide = typeof window !== 'undefined';
 
-  return function list<
-    Item extends Record<any, any>,
-    Props,
-    Bind extends BindableProps<Props> = BindableProps<Props>,
-  >(config: ReflectListConfig<Props, Item, Bind>): React.FC {
-    const ItemView = reflect<Props, Bind>({
-      view: config.view,
-      bind: config.bind ? config.bind : ({} as Bind),
-      hooks: config.hooks,
-    });
+export function list<
+  Item extends Record<any, any>,
+  Props,
+  Bind extends BindableProps<Props> = BindableProps<Props>,
+>(config: ReflectListConfig<Props, Item, Bind>): React.FC {
+  const ItemView = reflect<Props, Bind>({
+    view: config.view,
+    bind: config.bind ? config.bind : ({} as Bind),
+    hooks: config.hooks,
+  });
 
-    const listConfig = {
-      getKey: config.getKey,
-      fn: (value: Item, index: number) => {
-        const finalProps = React.useMemo(() => {
-          const props: any = {};
+  const listConfig = {
+    getKey: config.getKey,
+    fn: (value: Item, index: number) => {
+      const finalProps = React.useMemo(() => {
+        const props: any = {};
 
-          if (config.mapItem) {
-            forIn(config.mapItem, (prop) => {
-              const fn =
-                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                config.mapItem![prop];
-              const propValue = fn(value, index);
+        if (config.mapItem) {
+          forIn(config.mapItem, (prop) => {
+            const fn =
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+              config.mapItem![prop];
+            const propValue = fn(value, index);
 
-              props[prop] = propValue;
-            });
-          } else {
-            forIn(value, (prop) => {
-              props[prop] = value[prop];
-            });
-          }
+            props[prop] = propValue;
+          });
+        } else {
+          forIn(value, (prop) => {
+            props[prop] = value[prop];
+          });
+        }
 
-          return props;
-        }, [value, index]);
+        return props;
+      }, [value, index]);
 
-        return React.createElement(ItemView, finalProps);
-      },
-    };
-
-    return () => context.useList(config.source, listConfig);
+      return React.createElement(ItemView, finalProps);
+    },
   };
+
+  return () => useList(config.source, listConfig, { forceScope: !isClientSide });
 }
 
 function forIn<T extends Record<any, any>, R extends any>(

--- a/src/core/reflect.ts
+++ b/src/core/reflect.ts
@@ -12,49 +12,43 @@ export interface ReflectConfig<Props, Bind extends BindableProps<Props>> {
 
 const isClientSide = typeof window !== 'undefined';
 
-export function reflectCreateFactory() {
-  const reflect = reflectFactory();
-
-  return function createReflect<Props>(view: View<Props>) {
-    return <Bind extends BindableProps<Props> = BindableProps<Props>>(
-      bind: Bind,
-      params?: Pick<ReflectConfig<Props, Bind>, 'hooks'>,
-    ) => reflect<Props, Bind>({ view, bind, ...params });
-  };
+export function createReflect<Props>(view: View<Props>) {
+  return <Bind extends BindableProps<Props> = BindableProps<Props>>(
+    bind: Bind,
+    params?: Pick<ReflectConfig<Props, Bind>, 'hooks'>,
+  ) => reflect<Props, Bind>({ view, bind, ...params });
 }
 
-export function reflectFactory() {
-  return function reflect<
-    Props,
-    Bind extends BindableProps<Props> = BindableProps<Props>,
-  >(config: ReflectConfig<Props, Bind>): React.FC<PartialBoundProps<Props, Bind>> {
-    const { stores, events, data } = sortProps(config);
+export function reflect<
+  Props,
+  Bind extends BindableProps<Props> = BindableProps<Props>,
+>(config: ReflectConfig<Props, Bind>): React.FC<PartialBoundProps<Props, Bind>> {
+  const { stores, events, data } = sortProps(config);
 
-    return (props) => {
-      const storeProps = useUnit(stores, { forceScope: !isClientSide });
-      const eventsProps = useUnit(events, { forceScope: !isClientSide });
+  return (props) => {
+    const storeProps = useUnit(stores, { forceScope: !isClientSide });
+    const eventsProps = useUnit(events, { forceScope: !isClientSide });
 
-      const elementProps: Props = Object.assign(
-        {},
-        storeProps,
-        eventsProps,
-        data,
-        props,
-      );
+    const elementProps: Props = Object.assign(
+      {},
+      storeProps,
+      eventsProps,
+      data,
+      props,
+    );
 
-      const mounted = wrapToHook(config.hooks?.mounted);
-      const unmounted = wrapToHook(config.hooks?.unmounted);
+    const mounted = wrapToHook(config.hooks?.mounted);
+    const unmounted = wrapToHook(config.hooks?.unmounted);
 
-      React.useEffect(() => {
-        if (mounted) mounted();
+    React.useEffect(() => {
+      if (mounted) mounted();
 
-        return () => {
-          if (unmounted) unmounted();
-        };
-      }, []);
+      return () => {
+        if (unmounted) unmounted();
+      };
+    }, []);
 
-      return React.createElement(config.view as any, elementProps as any);
-    };
+    return React.createElement(config.view as any, elementProps as any);
   };
 }
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,11 +1,5 @@
 import { Effect, Event, Store } from 'effector';
-import { useList, useUnit } from 'effector-react';
 import { ComponentClass, FC } from 'react';
-
-export interface Context {
-  useUnit: typeof useUnit;
-  useList: typeof useList;
-}
 
 type Storify<Prop> = Omit<Store<Prop>, 'updates' | 'reset' | 'on' | 'off' | 'thru'>;
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,6 +1,10 @@
 import { Effect, Event, Store } from 'effector';
 import { ComponentClass, FC } from 'react';
 
+export interface Context {
+  forceScope?: boolean;
+}
+
 type Storify<Prop> = Omit<Store<Prop>, 'updates' | 'reset' | 'on' | 'off' | 'thru'>;
 
 export type BindableProps<Props> = {

--- a/src/core/variant.ts
+++ b/src/core/variant.ts
@@ -1,76 +1,68 @@
 import { Store } from 'effector';
+import { useUnit } from 'effector-react';
 import React from 'react';
 
-import { reflectFactory } from './reflect';
-import {
-  AtLeastOne,
-  BindableProps,
-  Context,
-  Hooks,
-  PartialBoundProps,
-  View,
-} from './types';
+import { reflect } from './reflect';
+import { AtLeastOne, BindableProps, Hooks, PartialBoundProps, View } from './types';
 
 const Default = () => null;
 
-export function variantFactory(context: Context) {
-  const reflect = reflectFactory(context);
+const isClientSide = typeof window !== 'undefined';
 
-  return function variant<
-    Props,
-    Variant extends string,
-    Bind extends BindableProps<Props>,
-  >(
-    config:
-      | {
-          source: Store<Variant>;
-          bind?: Bind;
-          cases: AtLeastOne<Record<Variant, View<Props>>>;
-          hooks?: Hooks;
-          default?: View<Props>;
-        }
-      | {
-          if: Store<boolean>;
-          then: View<Props>;
-          else?: View<Props>;
-          hooks?: Hooks;
-          bind?: Bind;
-        },
-  ): React.FC<PartialBoundProps<Props, Bind>> {
-    let $case: Store<Variant>;
-    let cases: AtLeastOne<Record<Variant, View<Props>>>;
-    let def: View<Props>;
+export function variant<
+  Props,
+  Variant extends string,
+  Bind extends BindableProps<Props>,
+>(
+  config:
+    | {
+        source: Store<Variant>;
+        bind?: Bind;
+        cases: AtLeastOne<Record<Variant, View<Props>>>;
+        hooks?: Hooks;
+        default?: View<Props>;
+      }
+    | {
+        if: Store<boolean>;
+        then: View<Props>;
+        else?: View<Props>;
+        hooks?: Hooks;
+        bind?: Bind;
+      },
+): React.FC<PartialBoundProps<Props, Bind>> {
+  let $case: Store<Variant>;
+  let cases: AtLeastOne<Record<Variant, View<Props>>>;
+  let def: View<Props>;
 
-    // Shortcut for Store<boolean>
-    if ('if' in config) {
-      $case = config.if.map((value): Variant => (value ? 'then' : 'else') as Variant);
+  // Shortcut for Store<boolean>
+  if ('if' in config) {
+    $case = config.if.map((value): Variant => (value ? 'then' : 'else') as Variant);
 
-      cases = {
-        then: config.then,
-        else: config.else,
-      } as unknown as AtLeastOne<Record<Variant, View<Props>>>;
-      def = Default;
-    }
-    // Full form for Store<string>
-    else {
-      $case = config.source;
-      cases = config.cases;
-      def = config.default ?? Default;
-    }
+    cases = {
+      then: config.then,
+      else: config.else,
+    } as unknown as AtLeastOne<Record<Variant, View<Props>>>;
+    def = Default;
+  }
+  // Full form for Store<string>
+  else {
+    $case = config.source;
+    cases = config.cases;
+    def = config.default ?? Default;
+  }
 
-    function View(props: Props) {
-      const nameOfCase = context.useUnit($case);
-      const Component = cases[nameOfCase] ?? def;
+  function View(props: Props) {
+    const nameOfCase = useUnit($case, { forceScope: !isClientSide });
+    const Component = cases[nameOfCase] ?? def;
 
-      return React.createElement(Component as any, props as any);
-    }
+    return React.createElement(Component as any, props as any);
+  }
 
-    const bind = config.bind ?? ({} as Bind);
+  const bind = config.bind ?? ({} as Bind);
 
-    return reflect({
-      bind,
-      view: View,
-      hooks: config.hooks,
-    });
-  };
+  return reflect({
+    bind,
+    view: View,
+    hooks: config.hooks,
+  });
 }

--- a/src/core/variant.ts
+++ b/src/core/variant.ts
@@ -2,67 +2,77 @@ import { Store } from 'effector';
 import { useUnit } from 'effector-react';
 import React from 'react';
 
-import { reflect } from './reflect';
-import { AtLeastOne, BindableProps, Hooks, PartialBoundProps, View } from './types';
+import { reflectFactory } from './reflect';
+import {
+  AtLeastOne,
+  BindableProps,
+  Context,
+  Hooks,
+  PartialBoundProps,
+  View,
+} from './types';
 
 const Default = () => null;
+const defaultContext: Context = { forceScope: false };
 
-const isClientSide = typeof window !== 'undefined';
+export function variantFactory(context: Context = defaultContext) {
+  const reflect = reflectFactory(context);
 
-export function variant<
-  Props,
-  Variant extends string,
-  Bind extends BindableProps<Props>,
->(
-  config:
-    | {
-        source: Store<Variant>;
-        bind?: Bind;
-        cases: AtLeastOne<Record<Variant, View<Props>>>;
-        hooks?: Hooks;
-        default?: View<Props>;
-      }
-    | {
-        if: Store<boolean>;
-        then: View<Props>;
-        else?: View<Props>;
-        hooks?: Hooks;
-        bind?: Bind;
-      },
-): React.FC<PartialBoundProps<Props, Bind>> {
-  let $case: Store<Variant>;
-  let cases: AtLeastOne<Record<Variant, View<Props>>>;
-  let def: View<Props>;
+  return function variant<
+    Props,
+    Variant extends string,
+    Bind extends BindableProps<Props>,
+  >(
+    config:
+      | {
+          source: Store<Variant>;
+          bind?: Bind;
+          cases: AtLeastOne<Record<Variant, View<Props>>>;
+          hooks?: Hooks;
+          default?: View<Props>;
+        }
+      | {
+          if: Store<boolean>;
+          then: View<Props>;
+          else?: View<Props>;
+          hooks?: Hooks;
+          bind?: Bind;
+        },
+  ): React.FC<PartialBoundProps<Props, Bind>> {
+    let $case: Store<Variant>;
+    let cases: AtLeastOne<Record<Variant, View<Props>>>;
+    let def: View<Props>;
 
-  // Shortcut for Store<boolean>
-  if ('if' in config) {
-    $case = config.if.map((value): Variant => (value ? 'then' : 'else') as Variant);
+    // Shortcut for Store<boolean>
+    if ('if' in config) {
+      $case = config.if.map((value): Variant => (value ? 'then' : 'else') as Variant);
 
-    cases = {
-      then: config.then,
-      else: config.else,
-    } as unknown as AtLeastOne<Record<Variant, View<Props>>>;
-    def = Default;
-  }
-  // Full form for Store<string>
-  else {
-    $case = config.source;
-    cases = config.cases;
-    def = config.default ?? Default;
-  }
+      cases = {
+        then: config.then,
+        else: config.else,
+      } as unknown as AtLeastOne<Record<Variant, View<Props>>>;
+      def = Default;
+    }
+    // Full form for Store<string>
+    else {
+      $case = config.source;
+      cases = config.cases;
+      def = config.default ?? Default;
+    }
 
-  function View(props: Props) {
-    const nameOfCase = useUnit($case, { forceScope: !isClientSide });
-    const Component = cases[nameOfCase] ?? def;
+    function View(props: Props) {
+      const nameOfCase = useUnit($case, { forceScope: context.forceScope });
+      const Component = cases[nameOfCase] ?? def;
 
-    return React.createElement(Component as any, props as any);
-  }
+      return React.createElement(Component as any, props as any);
+    }
 
-  const bind = config.bind ?? ({} as Bind);
+    const bind = config.bind ?? ({} as Bind);
 
-  return reflect({
-    bind,
-    view: View,
-    hooks: config.hooks,
-  });
+    return reflect({
+      bind,
+      view: View,
+      hooks: config.hooks,
+    });
+  };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,11 @@
-export * from './core';
+import {
+  listFactory,
+  reflectCreateFactory,
+  reflectFactory,
+  variantFactory,
+} from './core';
+
+export const reflect = reflectFactory();
+export const createReflect = reflectCreateFactory();
+export const variant = variantFactory();
+export const list = listFactory();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,1 @@
-import * as context from 'effector-react';
-
-import {
-  listFactory,
-  reflectCreateFactory,
-  reflectFactory,
-  variantFactory,
-} from './core';
-
-export const reflect = reflectFactory(context);
-export const createReflect = reflectCreateFactory(context);
-
-export const variant = variantFactory(context);
-
-export const list = listFactory(context);
+export * from './core';

--- a/src/scope.ts
+++ b/src/scope.ts
@@ -1,15 +1,5 @@
-import * as effectorReactSSR from 'effector-react/scope';
+console.info(
+  '`@effector/reflect/scope` is the same as `@effector/reflect`, so you can import from `@effector/reflect`',
+);
 
-import {
-  listFactory,
-  reflectCreateFactory,
-  reflectFactory,
-  variantFactory,
-} from './core';
-
-export const reflect = reflectFactory(effectorReactSSR);
-export const createReflect = reflectCreateFactory(effectorReactSSR);
-
-export const variant = variantFactory(effectorReactSSR);
-
-export const list = listFactory(effectorReactSSR);
+export * from './core';

--- a/src/scope.ts
+++ b/src/scope.ts
@@ -1,5 +1,14 @@
-console.info(
-  '`@effector/reflect/scope` is the same as `@effector/reflect`, so you can import from `@effector/reflect`',
-);
+import {
+  Context,
+  listFactory,
+  reflectCreateFactory,
+  reflectFactory,
+  variantFactory,
+} from './core';
 
-export * from './core';
+const scopeContext: Context = { forceScope: true };
+
+export const reflect = reflectFactory();
+export const createReflect = reflectCreateFactory(scopeContext);
+export const variant = variantFactory(scopeContext);
+export const list = listFactory(scopeContext);

--- a/src/scope.ts
+++ b/src/scope.ts
@@ -8,7 +8,7 @@ import {
 
 const scopeContext: Context = { forceScope: true };
 
-export const reflect = reflectFactory();
+export const reflect = reflectFactory(scopeContext);
 export const createReflect = reflectCreateFactory(scopeContext);
 export const variant = variantFactory(scopeContext);
 export const list = listFactory(scopeContext);


### PR DESCRIPTION
- The minimum version of `effector-react` is upgraded from `^22.1.0` to `^22.3.0`.

Closes #52 