### PR TITLE
Add `forceScope` support

### DIFF
--- a/dist-test/no-ssr/create-reflect.test.tsx
+++ b/dist-test/no-ssr/create-reflect.test.tsx
@@ -1,9 +1,10 @@
 import { createReflect } from '../../dist/reflect';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { createEffect, createEvent, createStore, restore } from 'effector';
+import { createEffect, createEvent, createStore, fork, restore } from 'effector';
 import React, { FC, InputHTMLAttributes } from 'react';
 import { act } from 'react-dom/test-utils';
+import { Provider } from 'effector-react';
 
 // Example1 (InputCustom)
 const InputCustom: FC<{
@@ -216,5 +217,32 @@ describe('hooks', () => {
 
       expect(fn.mock.calls.length).toBe(1);
     });
+  });
+});
+
+
+describe('forceScope', () => {
+  test('without provider', () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation();
+
+    const Input = inputBase({}, { forceScope: true });
+
+    expect(() => render(<Input />)).toThrowError(/no scope found/i);
+
+    spy.mockRestore();
+  });
+
+  test('with provider', () => {
+    const scope = fork();
+
+    const Input = inputBase({}, { forceScope: true });
+
+    const container = render(
+      <Provider value={scope}>
+        <Input data-testid="name" />
+      </Provider>,
+    );
+
+    expect(container.getByTestId('name')).toBeDefined();
   });
 });

--- a/dist-test/no-ssr/reflect.test.tsx
+++ b/dist-test/no-ssr/reflect.test.tsx
@@ -1,9 +1,10 @@
 import { reflect } from '../../dist/reflect';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { createEffect, createEvent, createStore, restore } from 'effector';
+import { createEffect, createEvent, createStore, fork, restore } from 'effector';
 import React, { ChangeEvent, FC, InputHTMLAttributes } from 'react';
 import { act } from 'react-dom/test-utils';
+import { Provider } from 'effector-react';
 
 // Example1 (InputCustom)
 const InputCustom: FC<{
@@ -229,5 +230,42 @@ describe('hooks', () => {
 
       expect(fn.mock.calls.length).toBe(1);
     });
+  });
+});
+
+describe('forceScope', () => {
+  test('without provider', () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation();
+
+    const $name = createStore('');
+
+    const Input = reflect({
+      view: InputBase,
+      bind: { defaultValue: $name },
+      forceScope: true,
+    });
+
+    expect(() => render(<Input />)).toThrowError(/no scope found/i);
+
+    spy.mockRestore();
+  });
+
+  test('with provider', () => {
+    const scope = fork();
+    const $name = createStore('');
+
+    const Input = reflect({
+      view: InputBase,
+      bind: { defaultValue: $name },
+      forceScope: true,
+    });
+
+    const container = render(
+      <Provider value={scope}>
+        <Input data-testid="name" />
+      </Provider>,
+    );
+
+    expect(container.getByTestId('name')).toBeDefined();
   });
 });

--- a/docs/pages/docs/reflect.mdx
+++ b/docs/pages/docs/reflect.mdx
@@ -1,8 +1,7 @@
-
 # `reflect`
 
 ```ts
-import {reflect} from '@effector/reflect'
+import { reflect } from '@effector/reflect';
 ```
 
 ```tsx
@@ -27,7 +26,7 @@ Static method to create a component bound to effector stores and events as store
 
 ## Example
 
-  ```tsx
+```tsx
 // ./user.tsx
 import { reflect } from '@effector/reflect';
 import { createEvent, restore } from 'effector';
@@ -82,4 +81,17 @@ export const User: FC = () => {
     </div>
   );
 };
+```
+
+## Scope enforcement
+
+`reflect` is designed to work with [Scope](https://effector.dev/docs/api/effector/scope) out-of-the-box, but you can require the use of Scope by passing an optional `forceScope` argument.
+
+```tsx
+const Component = reflect({
+  view: SourceComponent,
+  bind: Props,
+  hooks: Hooks,
+  forceScope: true,
+});
 ```

--- a/src/core/variant.ts
+++ b/src/core/variant.ts
@@ -13,8 +13,8 @@ import {
 
 const Default = () => null;
 
-export function variantFactory(context: Context) {
-  const reflect = reflectFactory(context);
+export function variantFactory<Scoped>(context: Context) {
+  const reflect = reflectFactory<Scoped>(context);
 
   return function variant<
     Props,
@@ -28,6 +28,7 @@ export function variantFactory(context: Context) {
           cases: AtLeastOne<Record<Variant, View<Props>>>;
           hooks?: Hooks;
           default?: View<Props>;
+          forceScope?: Scoped extends true ? never : boolean;
         }
       | {
           if: Store<boolean>;
@@ -35,6 +36,7 @@ export function variantFactory(context: Context) {
           else?: View<Props>;
           hooks?: Hooks;
           bind?: Bind;
+          forceScope?: Scoped extends true ? never : boolean;
         },
   ): React.FC<PartialBoundProps<Props, Bind>> {
     let $case: Store<Variant>;
@@ -59,7 +61,7 @@ export function variantFactory(context: Context) {
     }
 
     function View(props: Props) {
-      const nameOfCase = context.useUnit($case);
+      const nameOfCase = context.useUnit($case, { forceScope: config.forceScope });
       const Component = cases[nameOfCase] ?? def;
 
       return React.createElement(Component as any, props as any);
@@ -71,6 +73,7 @@ export function variantFactory(context: Context) {
       bind,
       view: View,
       hooks: config.hooks,
+      forceScope: config.forceScope,
     });
   };
 }

--- a/src/no-ssr/create-reflect.test.tsx
+++ b/src/no-ssr/create-reflect.test.tsx
@@ -1,6 +1,7 @@
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { createEffect, createEvent, createStore, restore } from 'effector';
+import { createEffect, createEvent, createStore, fork, restore } from 'effector';
+import { Provider } from 'effector-react';
 import React, { FC, InputHTMLAttributes } from 'react';
 import { act } from 'react-dom/test-utils';
 
@@ -104,6 +105,32 @@ test('InputBase', async () => {
 
   const inputAge = container.getByTestId('age') as HTMLInputElement;
   expect(inputAge.value).toBe('25');
+});
+
+describe('forceScope', () => {
+  test('without provider', () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation();
+
+    const Input = inputBase({}, { forceScope: true });
+
+    expect(() => render(<Input />)).toThrowError(/no scope found/i);
+
+    spy.mockRestore();
+  });
+
+  test('with provider', () => {
+    const scope = fork();
+
+    const Input = inputBase({}, { forceScope: true });
+
+    const container = render(
+      <Provider value={scope}>
+        <Input data-testid="name" />
+      </Provider>,
+    );
+
+    expect(container.getByTestId('name')).toBeDefined();
+  });
 });
 
 describe('hooks', () => {

--- a/src/no-ssr/list.test.tsx
+++ b/src/no-ssr/list.test.tsx
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/react';
-import { createEvent, createStore } from 'effector';
-import { useStore } from 'effector-react';
+import { createEvent, createStore, fork } from 'effector';
+import { Provider, useStore } from 'effector-react';
 import React, { FC, memo } from 'react';
 import { act } from 'react-dom/test-utils';
 
@@ -494,4 +494,40 @@ test('reflect-list: getKey option', async () => {
   expect(fn.mock.calls.map(([arg]) => arg)).toEqual(
     fn2.mock.calls.map(([arg]) => arg),
   );
+});
+
+describe('forceScope', () => {
+  const $members = createStore([{ name: 'alice', id: 1 }]);
+
+  test('without provider', () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation();
+
+    const MembersList = list({
+      source: $members,
+      view: Member,
+      forceScope: true,
+    });
+
+    expect(() => render(<MembersList />)).toThrowError(/no scope found/i);
+
+    spy.mockRestore();
+  });
+
+  test('with provider', () => {
+    const scope = fork();
+
+    const MembersList = list({
+      source: $members,
+      view: Member,
+      forceScope: true,
+    });
+
+    const container = render(
+      <Provider value={scope}>
+        <MembersList />
+      </Provider>,
+    );
+
+    expect(container.getByTestId('1')).toBeDefined();
+  });
 });

--- a/src/no-ssr/reflect.test.tsx
+++ b/src/no-ssr/reflect.test.tsx
@@ -1,6 +1,7 @@
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { createEffect, createEvent, createStore, restore } from 'effector';
+import { createEffect, createEvent, createStore, fork, restore } from 'effector';
+import { Provider } from 'effector-react';
 import React, { ChangeEvent, FC, InputHTMLAttributes } from 'react';
 import { act } from 'react-dom/test-utils';
 
@@ -157,6 +158,43 @@ test('forwardRef', async () => {
 
   const container = render(<Name ref={ref} />);
   expect(container.getByTestId('name')).toBe(ref.current);
+});
+
+describe('forceScope', () => {
+  test('without provider', () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation();
+
+    const $name = createStore('');
+
+    const Input = reflect({
+      view: InputBase,
+      bind: { defaultValue: $name },
+      forceScope: true,
+    });
+
+    expect(() => render(<Input />)).toThrowError(/no scope found/i);
+
+    spy.mockRestore();
+  });
+
+  test('with provider', () => {
+    const scope = fork();
+    const $name = createStore('');
+
+    const Input = reflect({
+      view: InputBase,
+      bind: { defaultValue: $name },
+      forceScope: true,
+    });
+
+    const container = render(
+      <Provider value={scope}>
+        <Input data-testid="name" />
+      </Provider>,
+    );
+
+    expect(container.getByTestId('name')).toBeDefined();
+  });
 });
 
 describe('hooks', () => {

--- a/src/scope.ts
+++ b/src/scope.ts
@@ -7,9 +7,9 @@ import {
   variantFactory,
 } from './core';
 
-export const reflect = reflectFactory(effectorReactSSR);
-export const createReflect = reflectCreateFactory(effectorReactSSR);
+export const reflect = reflectFactory<true>(effectorReactSSR);
+export const createReflect = reflectCreateFactory<true>(effectorReactSSR);
 
-export const variant = variantFactory(effectorReactSSR);
+export const variant = variantFactory<true>(effectorReactSSR);
 
-export const list = listFactory(effectorReactSSR);
+export const list = listFactory<true>(effectorReactSSR);

--- a/src/ssr/create-reflect.test.tsx
+++ b/src/ssr/create-reflect.test.tsx
@@ -1,4 +1,4 @@
-import { act, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { allSettled, createDomain, fork, restore } from 'effector';
 import { Provider } from 'effector-react/ssr';

--- a/src/ssr/reflect.test.tsx
+++ b/src/ssr/reflect.test.tsx
@@ -1,10 +1,10 @@
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { allSettled, createDomain, fork, restore } from 'effector';
+import { allSettled, createDomain, createStore, fork, restore } from 'effector';
 import { Provider } from 'effector-react/ssr';
 import React, { ChangeEvent, FC, InputHTMLAttributes } from 'react';
 
-import { reflect } from '../ssr';
+import { reflect } from '../scope';
 
 // Example1 (InputCustom)
 const InputCustom: FC<{
@@ -259,4 +259,21 @@ test('use only event for bind', async () => {
 
   expect(name.value).toBe('');
   expect(age.value).toBe('');
+});
+
+test('un-forcing scope does not work', () => {
+  const spy = jest.spyOn(console, 'error').mockImplementation();
+
+  const $name = createStore('');
+
+  const Input = reflect({
+    view: InputBase,
+    bind: { defaultValue: $name },
+    // @ts-expect-error trying to remove requirement for scope
+    forceScope: false,
+  });
+
+  expect(() => render(<Input />)).toThrowError(/no scope found/i);
+
+  spy.mockRestore();
 });

--- a/src/ssr/variant.test.tsx
+++ b/src/ssr/variant.test.tsx
@@ -4,7 +4,7 @@ import { allSettled, createDomain, fork, restore } from 'effector';
 import { Provider } from 'effector-react/ssr';
 import React from 'react';
 
-import { variant } from '../ssr';
+import { variant } from '../scope';
 
 test('matches first', async () => {
   const app = createDomain();

--- a/type-tests/types-list.tsx
+++ b/type-tests/types-list.tsx
@@ -155,3 +155,18 @@ import { list } from '../src';
 
   expectType<React.FC>(List);
 }
+
+// list allows forcing scope
+{
+  const Item: React.FC<{ id: number }> = () => null;
+
+  const $items = createStore<{ id: number }[]>([]);
+
+  const List = list({
+    source: $items,
+    view: Item,
+    forceScope: true,
+  });
+
+  expectType<React.FC>(List);
+}

--- a/type-tests/types-reflect-scope.tsx
+++ b/type-tests/types-reflect-scope.tsx
@@ -1,0 +1,17 @@
+import { expectType } from 'tsd';
+
+import { reflect } from '../src/scope';
+
+// reflect/scope does not allow passing forceScope
+{
+  const View: React.FC<{ value: string }> = () => null;
+
+  const ReflectedView = reflect({
+    view: View,
+    bind: { value: '' },
+    // @ts-expect-error
+    forceScope: true,
+  });
+
+  expectType<React.FC>(ReflectedView);
+}

--- a/type-tests/types-reflect.tsx
+++ b/type-tests/types-reflect.tsx
@@ -160,3 +160,16 @@ import { reflect } from '../src';
 
   expectType<React.FC>(App);
 }
+
+// reflect allows forcing scope
+{
+  const View: React.FC<{ value: string }> = () => null;
+
+  const ReflectedView = reflect({
+    view: View,
+    bind: { value: '' },
+    forceScope: true,
+  });
+
+  expectType<React.FC>(ReflectedView);
+}

--- a/type-tests/types-variant.tsx
+++ b/type-tests/types-variant.tsx
@@ -172,3 +172,16 @@ import { variant } from '../src';
   });
   expectType<React.FC>(CurrentPageOnlyThen);
 }
+
+// variant allows forcing scope
+{
+  const View: React.FC<{ value: string }> = () => null;
+
+  const VariantView = variant({
+    if: createStore(true),
+    then: View,
+    forceScope: true,
+  });
+
+  expectType<React.FC>(VariantView);
+}


### PR DESCRIPTION
Added support for `forceScope` to all methods. Exports from `/scope` do not accept this argument, as it has no effect (created a typing test for that).

I've also covered this behavior with unit tests, especially the non-scoped part. 

This is not a clone of https://github.com/effector/reflect/pull/67 (respect to @iposokhin for it), rather, a different take - I kept imports from `effector-react/scope`, so `reflect` uses the correct Context (as outlined in [beta docs](https://beta.effector.dev/en/api/effector-react/module/scope/#migration)). 