### PR TITLE
Allow effector 23

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,8 +107,8 @@
     "uglify-js": "^3.17.4"
   },
   "peerDependencies": {
-    "effector": "^22.0.0",
-    "effector-react": "^22.1.0",
+    "effector": "^22.0.0 || ^23.0.0",
+    "effector-react": "^22.1.0 || ^23.0.0",
     "react": ">=16.8.0 <19.0.0"
   }
 }


### PR DESCRIPTION
This PR allows usage of Reflect with Effector 23, but is not yet introducing advanced types support, so Effector 22 is still allowed too

Full-featured support of Effector 23 will come later.

