### PR TITLE
Adding intercept

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,3 +1,4 @@
 export { reflectFactory, reflectCreateFactory } from './reflect';
 export { variantFactory } from './variant';
 export { listFactory } from './list';
+export { intercept } from './intercept';

--- a/src/core/intercept.ts
+++ b/src/core/intercept.ts
@@ -1,0 +1,74 @@
+import { Event, is } from 'effector';
+import { ComponentRef, createElement, forwardRef, useEffect, useRef } from 'react';
+
+import { View } from './types';
+
+type PropsToEvents<Props extends Record<string, any>> = {
+  [key in keyof Props]?: Event<Props[key]>;
+};
+
+interface InterceptHooks<Events extends Partial<{ [key: string]: Event<any> }>> {
+  update?: Events;
+  mounted?: Events;
+  unmounted?: Events;
+}
+
+export const intercept =
+  <ViewProps extends Record<string, any>>(View: View<ViewProps>) =>
+  <ExtendedProps extends NonNullable<unknown>>(
+    propHooks: InterceptHooks<PropsToEvents<ViewProps & ExtendedProps>>,
+  ) =>
+    forwardRef<ComponentRef<View<ViewProps>>, ViewProps & ExtendedProps>(
+      (props, ref) => {
+        const propsRef = useRef<ViewProps & ExtendedProps>();
+
+        useEffect(() => {
+          Object.entries(props).map(([key, value]) => {
+            const canTriggerMountEvent =
+              is.event(propHooks.mounted?.[key]) && !propsRef.current;
+
+            if (canTriggerMountEvent) {
+              propHooks.mounted?.[key]?.(value);
+            }
+
+            const canTriggerUpdateEvent =
+              propHooks.update &&
+              is.event(propHooks?.update?.[key]) &&
+              propsRef.current &&
+              propsRef.current[key] !== value;
+
+            if (canTriggerUpdateEvent) {
+              propHooks.update?.[key]?.(value);
+            }
+          });
+
+          propsRef.current = props;
+        });
+
+        useEffect(() => {
+          return () => {
+            if (!propsRef.current) {
+              return;
+            }
+
+            Object.entries(propsRef.current).map(([key, value]) => {
+              const canTriggerUnmountEvent =
+                is.event(propHooks.unmounted?.[key]) && propsRef.current;
+
+              if (canTriggerUnmountEvent) {
+                propHooks.unmounted?.[key]?.(value);
+              }
+            });
+          };
+        }, []);
+
+        const propsWithRef = Object.assign(
+          {
+            ref,
+          },
+          props,
+        );
+
+        return createElement(View, propsWithRef);
+      },
+    );

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,8 @@ import {
   variantFactory,
 } from './core';
 
+export { intercept } from './core';
+
 export const reflect = reflectFactory(context);
 export const createReflect = reflectCreateFactory(context);
 

--- a/src/no-ssr/intercept.test.tsx
+++ b/src/no-ssr/intercept.test.tsx
@@ -1,0 +1,142 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createEvent } from 'effector';
+import React, { createRef, forwardRef, useState } from 'react';
+
+import { intercept } from '../core';
+
+const Input = forwardRef<
+  HTMLInputElement,
+  {
+    value: string;
+    onChange?: (value: string) => void;
+  }
+>(({ value, onChange }, ref) => (
+  <input ref={ref} value={value} onChange={(e) => onChange?.(e.target.value)} />
+));
+
+describe('intercept [no ssr]', () => {
+  describe('component', () => {
+    test('passing value', () => {
+      const Component = intercept(Input)({});
+
+      render(<Component value="test" />);
+
+      const input = screen.getByDisplayValue('test');
+
+      expect(input).not.toBeNull();
+    });
+
+    test('forward ref', async () => {
+      const Component = intercept(Input)({});
+
+      const ref = createRef<HTMLInputElement>();
+
+      render(<Component value="test" ref={ref} />);
+
+      const input = screen.getByDisplayValue('test');
+
+      expect(input).toBe(ref.current);
+    });
+
+    test('extended props', () => {
+      const setupValue = createEvent<boolean>();
+
+      const mockFn = jest.fn();
+
+      setupValue.watch(mockFn);
+
+      const Component = intercept(Input)<{ checked: boolean }>({
+        mounted: {
+          checked: setupValue,
+        },
+      });
+
+      render(<Component checked={true} value="" />);
+
+      expect(mockFn).toHaveBeenCalledWith(true);
+    });
+  });
+
+  describe('hooks', () => {
+    test('mounted', () => {
+      const setupValue = createEvent<string>();
+
+      const mockFn = jest.fn();
+
+      setupValue.watch(mockFn);
+
+      const Component = intercept(Input)({
+        mounted: {
+          value: setupValue,
+        },
+      });
+
+      render(<Component value="test" />);
+
+      expect(mockFn).toHaveBeenCalledWith('test');
+    });
+
+    test('update', async () => {
+      const changedValue = createEvent<string>();
+
+      const mockFn = jest.fn();
+
+      changedValue.watch(mockFn);
+
+      const InputComponent = intercept(Input)({
+        update: {
+          value: changedValue,
+        },
+      });
+
+      const Bloc = () => {
+        const [value, setValue] = useState('');
+
+        return <InputComponent value={value} onChange={setValue} />;
+      };
+
+      render(<Bloc />);
+
+      const input = screen.getByRole('textbox') as HTMLInputElement;
+
+      await userEvent.type(input, 'Ivan');
+
+      expect(mockFn).toHaveBeenLastCalledWith('Ivan');
+      expect(input.value).toBe('Ivan');
+    });
+
+    test('unmounted', async () => {
+      const lastValue = createEvent<string>();
+
+      const mockFn = jest.fn();
+
+      lastValue.watch(mockFn);
+
+      const InputComponent = intercept(Input)({
+        unmounted: {
+          value: lastValue,
+        },
+      });
+
+      const Bloc: React.FC<{ inputValue: string }> = ({ inputValue }) => {
+        const [visible, setVisible] = useState(true);
+
+        return (
+          <div>
+            <button onClick={() => setVisible(false)}>hide</button>
+            {visible && <InputComponent value={inputValue} />}
+          </div>
+        );
+      };
+
+      render(<Bloc inputValue="Peter" />);
+
+      const button = screen.getByRole('button');
+
+      await userEvent.click(button);
+
+      expect(mockFn).toHaveBeenCalledWith('Peter');
+    });
+  });
+});

--- a/src/ssr/intercept.test.tsx
+++ b/src/ssr/intercept.test.tsx
@@ -1,0 +1,149 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createDomain, fork } from 'effector';
+import { Provider } from 'effector-react/ssr';
+import React, { forwardRef, useState } from 'react';
+
+import { intercept } from '../core';
+
+const Input = forwardRef<
+  HTMLInputElement,
+  {
+    value: string;
+    onChange?: (value: string) => void;
+  }
+>(({ value, onChange }, ref) => (
+  <input ref={ref} value={value} onChange={(e) => onChange?.(e.target.value)} />
+));
+
+describe('intercept [ssr]', () => {
+  describe('component', () => {
+    test('extended props', () => {
+      const app = createDomain();
+      const setupValue = app.createEvent<boolean>();
+
+      const mockFn = jest.fn();
+
+      setupValue.watch(mockFn);
+
+      const Component = intercept(Input)<{ checked: boolean }>({
+        mounted: {
+          checked: setupValue,
+        },
+      });
+
+      const scope = fork(app);
+
+      render(
+        <Provider value={scope}>
+          <Component checked={true} value="" />
+        </Provider>,
+      );
+
+      expect(mockFn).toHaveBeenCalledWith(true);
+    });
+  });
+
+  describe('hooks', () => {
+    test('mounted', () => {
+      const app = createDomain();
+      const setupValue = app.createEvent<string>();
+
+      const mockFn = jest.fn();
+
+      setupValue.watch(mockFn);
+
+      const Component = intercept(Input)({
+        mounted: {
+          value: setupValue,
+        },
+      });
+
+      const scope = fork(app);
+
+      render(
+        <Provider value={scope}>
+          <Component value="test" />
+        </Provider>,
+      );
+
+      expect(mockFn).toHaveBeenCalledWith('test');
+    });
+
+    test('update', async () => {
+      const app = createDomain();
+      const changedValue = app.createEvent<string>();
+
+      const mockFn = jest.fn();
+
+      changedValue.watch(mockFn);
+
+      const InputComponent = intercept(Input)({
+        update: {
+          value: changedValue,
+        },
+      });
+
+      const Bloc = () => {
+        const [value, setValue] = useState('');
+
+        return <InputComponent value={value} onChange={setValue} />;
+      };
+
+      const scope = fork(app);
+
+      render(
+        <Provider value={scope}>
+          <Bloc />
+        </Provider>,
+      );
+
+      const input = screen.getByRole('textbox') as HTMLInputElement;
+
+      await userEvent.type(input, 'Ivan');
+
+      expect(mockFn).toHaveBeenLastCalledWith('Ivan');
+      expect(input.value).toBe('Ivan');
+    });
+
+    test('unmounted', async () => {
+      const app = createDomain();
+      const lastValue = app.createEvent<string>();
+
+      const mockFn = jest.fn();
+
+      lastValue.watch(mockFn);
+
+      const InputComponent = intercept(Input)({
+        unmounted: {
+          value: lastValue,
+        },
+      });
+
+      const Bloc: React.FC<{ inputValue: string }> = ({ inputValue }) => {
+        const [visible, setVisible] = useState(true);
+
+        return (
+          <div>
+            <button onClick={() => setVisible(false)}>hide</button>
+            {visible && <InputComponent value={inputValue} />}
+          </div>
+        );
+      };
+
+      const scope = fork(app);
+
+      render(
+        <Provider value={scope}>
+          <Bloc inputValue="Peter" />
+        </Provider>,
+      );
+
+      const button = screen.getByRole('button');
+
+      await userEvent.click(button);
+
+      expect(mockFn).toHaveBeenCalledWith('Peter');
+    });
+  });
+});


### PR DESCRIPTION
The main idea is to make it possible to react to changes in props in components

Scheme

![image](https://github.com/effector/reflect/assets/56914596/468a29bd-41b0-426c-8402-e6c1fb15d975)

Example

```
const Input = ({ value, onChange }: {
    value: string;
    onChange?: (value: string) => void;
  }) => (
  <input ref={ref} value={value} onChange={(e) => onChange?.(e.target.value)} />
);

const changedValue = createEvent<string>();

     const InputComponent = intercept(Input)({
        update: {
          value: changedValue ,
        },
      });
   
        const Bloc = () => {
        const [value, setValue] = useState('');

        return <InputComponent value={value} onChange={setValue} />;
      };

 changedValue.watch((value) => console.log("value was changed to", value));
```

