### PR TITLE
Allow to bind `EventCallable<void>` to an optional callback

### DIFF
--- a/public-types/reflect.d.ts
+++ b/public-types/reflect.d.ts
@@ -18,23 +18,21 @@ type Hooks<Props> = {
     | ((props: Props) => unknown);
 };
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type VoidCallback<T> = T extends (...args: any[]) => infer R ? () => R : never;
+
 /**
  * `bind` object type:
  * prop key -> store (unwrapped to reactive subscription) or any other value (used as is)
- *
- * Also handles some edge-cases like enforcing type inference for inlined callbacks
  */
 type BindFromProps<Props> = {
   [K in keyof Props]?: K extends UnbindableProps
     ? never
-    : Props[K] extends (...args: any[]) => any
-    ? // To force TS infer types for any provided callback
-      | ((...args: Parameters<Props[K]>) => ReturnType<Props[K]>)
-        // Edge-case: allow to pass an event listener without any parameters (e.g. onClick: () => ...)
-        | (() => ReturnType<Props[K]>)
-        // Edge-case: allow to pass a Store, which contains a function
+    :
         | Store<Props[K]>
-    : Store<Props[K]> | Props[K];
+        | Props[K]
+        // case: allow Event<void> for callbacks with arbitrary arguments
+        | VoidCallback<Props[K]>;
 };
 
 /**

--- a/type-tests/types-reflect.tsx
+++ b/type-tests/types-reflect.tsx
@@ -210,6 +210,26 @@ import { expectType } from 'tsd';
   expectType<React.FC>(ReflectedButton);
 }
 
+// reflect should allow passing Event<void> as callback to optional event handlers
+{
+  const Button: React.FC<{
+    onOptional?: React.EventHandler<React.MouseEvent<HTMLButtonElement>>;
+    onNull: React.MouseEventHandler<HTMLButtonElement> | null;
+  }> = () => null;
+
+  const event = createEvent<void>();
+
+  const ReflectedButton = reflect({
+    view: Button,
+    bind: {
+      onOptional: event,
+      onNull: event,
+    },
+  });
+
+  expectType<React.FC>(ReflectedButton);
+}
+
 // reflect should not allow binding ref
 {
   const Text = React.forwardRef(


### PR DESCRIPTION
Right now public types prohibit binding `EventCallable<void>` to an optional prop.

`Props[K] extends (...args: any[]) => any` does not get distributed over unions, and does not handle unions that combine function and non-function type, like `MouseEventHandler | undefined`.

This is fixed by consolidating branches and moving `payload: void` case into a separate type that does distribute.

Reproduction: https://tsplay.dev/reflect-event-void-bind