### PR TITLE
fix(types): relax variant behavior on incompatible props

### DIFF
--- a/public-types/reflect.d.ts
+++ b/public-types/reflect.d.ts
@@ -185,6 +185,22 @@ export function list<
 // variant types
 
 /**
+ * Computes final props type based on Props of the view component and Bind object for variant operator specifically
+ *
+ * Difference is important since in variant case Props is a union
+ *
+ * Props that are "taken" by Bind object are made **optional** in the final type,
+ * so it is possible to overwrite them in the component usage anyway
+ */
+type FinalPropsVariant<Props, Bind extends BindFromProps<Props>> = Show<
+  Props extends any
+    ? Omit<Props, keyof Bind> & {
+        [K in Extract<keyof Bind, keyof Props>]?: Props[K];
+      }
+    : never
+>;
+
+/**
  * Operator to conditionally render a component based on the reactive `source` store value.
  *
  * @example
@@ -237,7 +253,7 @@ export function variant<
          */
         useUnitConfig?: UseUnitConfig;
       },
-): FC<FinalProps<Props, Bind>>;
+): FC<FinalPropsVariant<Props, Bind>>;
 
 // fromTag types
 /**

--- a/public-types/reflect.d.ts
+++ b/public-types/reflect.d.ts
@@ -206,8 +206,9 @@ export function list<
  * ```
  */
 export function variant<
-  Props,
   CaseType extends string,
+  Cases extends Record<CaseType, ComponentType<any>>,
+  Props extends ComponentProps<Cases[CaseType]>,
   // It is ok here - it fixed bunch of type inference issues, when `bind` is not provided
   // but it is not clear why it works this way - Record<string, never> or any option other than `{}` doesn't work
   // eslint-disable-next-line @typescript-eslint/ban-types
@@ -216,7 +217,7 @@ export function variant<
   config:
     | {
         source: Store<CaseType>;
-        cases: Partial<Record<CaseType, ComponentType<Props>>>;
+        cases: Partial<Cases>;
         default?: ComponentType<Props>;
         bind?: Bind;
         hooks?: Hooks<Props>;

--- a/type-tests/types-variant.tsx
+++ b/type-tests/types-variant.tsx
@@ -34,7 +34,7 @@ import { expectType } from 'tsd';
   expectType<React.FC>(VariableInput);
 }
 
-// variant catches incompatible props between cases
+// variant allows to pass incompatible props between cases - resulting component will have union of all props from all cases
 {
   const Input: React.FC<{
     value: string;
@@ -56,7 +56,6 @@ import { expectType } from 'tsd';
     },
     cases: {
       input: Input,
-      // @ts-expect-error
       datetime: DateTime,
     },
   });
@@ -264,7 +263,6 @@ import { expectType } from 'tsd';
     },
     cases: {
       button: Button<'button'>,
-      // @ts-expect-error
       a: Button<'a'>,
     },
   });
@@ -277,7 +275,6 @@ import { expectType } from 'tsd';
     },
     cases: {
       button: Button<'button'>,
-      // @ts-expect-error
       a: Button<'a'>,
     },
   });

--- a/type-tests/types-variant.tsx
+++ b/type-tests/types-variant.tsx
@@ -61,6 +61,33 @@ import { expectType } from 'tsd';
   });
 
   <VariableInput />;
+  <VariableInput value="test" />;
+  <VariableInput
+    value="test"
+    onChange={(event: { target: { value: string } }) => {
+      event.target.value;
+    }}
+  />;
+  <VariableInput
+    value="test"
+    onChange={() => {
+      // ok
+    }}
+  />;
+  <VariableInput
+    value="test"
+    onChange={(event: string) => {
+      event;
+    }}
+  />;
+  <VariableInput
+    // @ts-expect-error
+    value={42}
+    // @ts-expect-error
+    onChange={(event: number) => {
+      event;
+    }}
+  />;
 }
 
 // variant allows not to set every possble case
@@ -89,6 +116,9 @@ import { expectType } from 'tsd';
   });
 
   <CurrentPage />;
+  <CurrentPage context={{ route: 'home' }} />;
+  // @ts-expect-error
+  <CurrentPage context="kek" />;
 }
 
 // variant warns about wrong cases
@@ -117,6 +147,9 @@ import { expectType } from 'tsd';
   });
 
   <CurrentPage />;
+  <CurrentPage context={{ route: 'home' }} />;
+  // @ts-expect-error
+  <CurrentPage context="kek" />;
 }
 
 // overload for boolean source
@@ -141,6 +174,9 @@ import { expectType } from 'tsd';
   });
 
   <CurrentPageThenElse />;
+  <CurrentPageThenElse context={{ route: 'home' }} />;
+  // @ts-expect-error
+  <CurrentPageThenElse context="kek" />;
 
   const CurrentPageOnlyThen = variant({
     if: $enabled,
@@ -148,6 +184,9 @@ import { expectType } from 'tsd';
     bind: { context: $ctx },
   });
   <CurrentPageOnlyThen />;
+  <CurrentPageOnlyThen context={{ route: 'home' }} />;
+  // @ts-expect-error
+  <CurrentPageOnlyThen context="kek" />;
 }
 
 // supports nesting
@@ -169,6 +208,8 @@ import { expectType } from 'tsd';
       }),
     },
   });
+
+  <NestedVariant />;
 }
 
 // allows variants of compatible types
@@ -188,6 +229,10 @@ import { expectType } from 'tsd';
     }),
     else: Loader,
   });
+
+  <View test="test" />;
+  // @ts-expect-error
+  <View test={42} />;
 }
 
 // Issue #81 reproduce 1
@@ -280,12 +325,22 @@ import { expectType } from 'tsd';
     },
   });
 
+  <ReflectedVariantBad />;
+  <ReflectedVariantBad size="xl" />;
+  // @ts-expect-error
+  <ReflectedVariantBad size={52} />;
+
   const IfElseVariant = variant({
     if: createStore(true),
     then: Button<'button'>,
     // @ts-expect-error
     else: Button<'a'>,
   });
+
+  <IfElseVariant />;
+  <IfElseVariant size="xl" />;
+  // @ts-expect-error
+  <IfElseVariant size={52} />;
 }
 
 // variant should allow not-to pass required props - as they can be added later in react


### PR DESCRIPTION
`variant` blocking on "incompatible props" use-case is bad for DX it only protects against bad spreads, which are antipattern anyway