### PR TITLE
fix: do not spawn additional stores inside variant

### DIFF
--- a/src/core/variant.ts
+++ b/src/core/variant.ts
@@ -38,8 +38,7 @@ export function variantFactory(context: Context) {
 
     // Shortcut for Store<boolean>
     if ('if' in config) {
-      $case = config.if.map((value): Variant => (value ? 'then' : 'else') as Variant);
-
+      $case = config.if as any;
       cases = {
         then: config.then,
         else: config.else,
@@ -54,7 +53,10 @@ export function variantFactory(context: Context) {
     }
 
     function View(props: Props) {
-      const nameOfCase = context.useUnit($case, config.useUnitConfig);
+      const nameOfCaseRaw = context.useUnit($case, config.useUnitConfig);
+      const nameOfCase = (
+        'if' in config ? ifToVariant(nameOfCaseRaw as any) : nameOfCaseRaw
+      ) as Variant;
       const Component = cases[nameOfCase] ?? def;
 
       return React.createElement(Component as any, props as any);
@@ -69,4 +71,8 @@ export function variantFactory(context: Context) {
       useUnitConfig: config.useUnitConfig,
     }) as unknown as (p: Props) => React.ReactNode;
   };
+}
+
+function ifToVariant(value: boolean): 'then' | 'else' {
+  return value ? 'then' : 'else';
 }

--- a/src/core/variant.ts
+++ b/src/core/variant.ts
@@ -32,13 +32,13 @@ export function variantFactory(context: Context) {
           useUnitConfig?: UseUnitConifg;
         },
   ): (p: Props) => React.ReactNode {
-    let $case: Store<Variant>;
+    let $case: Store<Variant | boolean>;
     let cases: Record<Variant, View<Props>>;
     let def: View<Props>;
 
     // Shortcut for Store<boolean>
     if ('if' in config) {
-      $case = config.if as any;
+      $case = config.if;
       cases = {
         then: config.then,
         else: config.else,
@@ -53,10 +53,7 @@ export function variantFactory(context: Context) {
     }
 
     function View(props: Props) {
-      const nameOfCaseRaw = context.useUnit(
-        $case as Store<string | boolean>,
-        config.useUnitConfig,
-      );
+      const nameOfCaseRaw = context.useUnit($case, config.useUnitConfig);
       const nameOfCase = (
         typeof nameOfCaseRaw === 'string'
           ? nameOfCaseRaw

--- a/src/core/variant.ts
+++ b/src/core/variant.ts
@@ -60,7 +60,7 @@ export function variantFactory(context: Context) {
       const nameOfCase = (
         typeof nameOfCaseRaw === 'string'
           ? nameOfCaseRaw
-          : booleanToVariant(nameOfCaseRaw as boolean)
+          : booleanToVariant(nameOfCaseRaw)
       ) as Variant;
       const Component = cases[nameOfCase] ?? def;
 

--- a/src/core/variant.ts
+++ b/src/core/variant.ts
@@ -53,9 +53,14 @@ export function variantFactory(context: Context) {
     }
 
     function View(props: Props) {
-      const nameOfCaseRaw = context.useUnit($case, config.useUnitConfig);
+      const nameOfCaseRaw = context.useUnit(
+        $case as Store<string | boolean>,
+        config.useUnitConfig,
+      );
       const nameOfCase = (
-        'if' in config ? ifToVariant(nameOfCaseRaw as any) : nameOfCaseRaw
+        typeof nameOfCaseRaw === 'string'
+          ? nameOfCaseRaw
+          : booleanToVariant(nameOfCaseRaw as boolean)
       ) as Variant;
       const Component = cases[nameOfCase] ?? def;
 
@@ -73,6 +78,6 @@ export function variantFactory(context: Context) {
   };
 }
 
-function ifToVariant(value: boolean): 'then' | 'else' {
+function booleanToVariant(value: boolean): 'then' | 'else' {
   return value ? 'then' : 'else';
 }


### PR DESCRIPTION
`variant` is spawning a `.map` store in simplified overload - it is messing with the effector's babel/swc code for Hot Module Reload

To avoid special handling for HMR with reflect we are refactoring this `.map` store to a mapping inside a react-component

No changes for runtime behavior otherwise