### PR TITLE
fix: move @vite/plugin-react to `devDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@types/jest": "^26.0.24",
     "@types/react": "^19.0.12",
     "@types/react-dom": "^19.0.4",
+    "@vitejs/plugin-react": "^4.3.4",
     "babel-jest": "^29.7.0",
     "babel-plugin-module-resolver": "^4.1.0",
     "effector": "^23.3.0",
@@ -102,8 +103,5 @@
     "effector": "^23.1.0",
     "effector-react": "^23.1.0",
     "react": ">=16.8.0 <20.0.0"
-  },
-  "dependencies": {
-    "@vitejs/plugin-react": "^4.3.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,10 +7,6 @@ settings:
 importers:
 
   .:
-    dependencies:
-      '@vitejs/plugin-react':
-        specifier: ^4.3.4
-        version: 4.3.4(vite@5.4.14(@types/node@22.13.11)(terser@5.39.0))
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.13.10
@@ -66,6 +62,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.0.4
         version: 19.0.4(@types/react@19.0.12)
+      '@vitejs/plugin-react':
+        specifier: ^4.3.4
+        version: 4.3.4(vite@5.4.14(@types/node@22.13.11)(terser@5.39.0))
       babel-jest:
         specifier: ^29.7.0
         version: 29.7.0(@babel/core@7.26.10)


### PR DESCRIPTION
Looks like `@vite/plugin-react` should be listed in `devDependencies`.

Here is output from NextJS project:
```
❯ bun why vite --depth=2
vite@7.3.1
  └─ peer @vitejs/plugin-react@4.7.0 (requires ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0)
     └─ @effector/reflect@10.0.2 (requires ^4.3.4)
        └─ (deeper dependencies hidden)
```