### PR TITLE
add `mapProps` for `reflect()` to derive view props from store state and props

### DIFF
--- a/docs/pages/docs/reflect.mdx
+++ b/docs/pages/docs/reflect.mdx
@@ -18,6 +18,7 @@ Static method to create a component bound to effector stores and events as store
 
 1. `view` — A react component that should be used to bind to
 1. `bind` — Object of effector stores, events or any value
+1. `mapProps` — Optional object of derived props. Each entry computes a prop for the `view` from a store value combined with the component's own props.
 1. [`hooks`](/docs/hooks) — Optional object `{ mounted, unmounted }` to handle when component is mounted or unmounted.
 1. `useUnitConfig` - Optional configuration object, which is passed directly to the second argument of `useUnit` from `effector-react`.
 
@@ -80,6 +81,52 @@ export const User: FC = () => {
   );
 };
 ```
+
+## Deriving props with `mapProps`
+
+Sometimes a prop is not just a store value or a plain value, but a combination of a store's
+state **and** the props passed to the component. For these cases use `mapProps`.
+
+Each entry is `{ source, fn }`:
+
+- `source` — a store (use `combine(...)` to derive from several stores) the value is read from reactively;
+- `fn` — `(value, props) => derivedProp`, where `value` is the `source` store value and `props` are the component's own props.
+
+```tsx
+import { reflect } from '@effector/reflect';
+import { createStore } from 'effector';
+import React, { FC } from 'react';
+
+type GreetingProps = {
+  title: string;
+  label: string;
+};
+
+const Greeting: FC<GreetingProps> = ({ label }) => <span>{label}</span>;
+
+const $user = createStore({ name: 'Bob' });
+
+const Hello = reflect({
+  view: Greeting,
+  bind: {},
+  mapProps: {
+    // `label` is derived from the `$user` store and the incoming `title` prop
+    label: {
+      source: $user,
+      fn: (user, props) => `${props.title} ${user.name}`,
+    },
+  },
+});
+
+// usage: `label` becomes optional, since it is derived
+export const App: FC = () => <Hello title="Hello," />;
+```
+
+The component re-renders only when the `source` store changes. A prop computed via `mapProps`
+is made **optional** in the resulting component's type and can still be overridden explicitly at
+the usage site (an explicitly passed prop wins over the derived value).
+
+> Note: like `bind`, the `mapProps` field is supported by all Reflect operators — `reflect`, `createReflect`, `variant` and `list`.
 
 ### Fork API auto-compatibility
 

--- a/docs/pages/docs/reflect.mdx
+++ b/docs/pages/docs/reflect.mdx
@@ -89,8 +89,11 @@ state **and** the props passed to the component. For these cases use `mapProps`.
 
 Each entry is `{ source, fn }`:
 
-- `source` — a store (use `combine(...)` to derive from several stores) the value is read from reactively;
-- `fn` — `(value, props) => derivedProp`, where `value` is the `source` store value and `props` are the component's own props.
+- `source` — what the derived value is read from reactively. Like `combine` / `useUnit`, it can be:
+  - a single store — `value` is its state;
+  - an **object** of stores — `value` is the resolved object (`{ a: Store<A> }` → `{ a: A }`);
+  - an **array** of stores — `value` is the resolved tuple (`[Store<A>, Store<B>]` → `[A, B]`).
+- `fn` — `(value, props) => derivedProp`, where `value` is the resolved `source` value (its type is inferred — no annotation needed) and `props` are the component's own props.
 
 ```tsx
 import { reflect } from '@effector/reflect';
@@ -122,7 +125,23 @@ const Hello = reflect({
 export const App: FC = () => <Hello title="Hello," />;
 ```
 
-The component re-renders only when the `source` store changes. A prop computed via `mapProps`
+To derive from several stores at once, pass an object (or array) of stores as `source`:
+
+```tsx
+const Hello = reflect({
+  view: Greeting,
+  bind: {},
+  mapProps: {
+    label: {
+      source: { user: $user, count: $count },
+      // `s` is inferred as { user: { name: string }; count: number }
+      fn: (s, props) => `${props.title} ${s.user.name} (${s.count})`,
+    },
+  },
+});
+```
+
+The component re-renders only when the `source` changes. A prop computed via `mapProps`
 is made **optional** in the resulting component's type and can still be overridden explicitly at
 the usage site (an explicitly passed prop wins over the derived value).
 

--- a/public-types/reflect.d.ts
+++ b/public-types/reflect.d.ts
@@ -42,14 +42,42 @@ type BindFromProps<Props> = {
 };
 
 /**
- * Computes final props type based on Props of the view component and Bind object.
+ * `mapProps` object type:
+ * prop key -> a derived prop computed from a store value and the component's props.
  *
- * Props that are "taken" by Bind object are made **optional** in the final type,
+ * Use it to combine a store state with the incoming props to produce a prop for the `view`.
+ *
+ * `Keys` is captured from the actual config to know which props become overridable in the
+ * final type. The `value` of `fn` is intentionally loose (`any`) - annotate it if needed -
+ * while `props` is contextually typed as the view's `Props`.
+ */
+type MapPropsFromProps<
+  Props,
+  Keys extends Exclude<keyof Props, UnbindableProps> = Exclude<
+    keyof Props,
+    UnbindableProps
+  >,
+> = {
+  [K in Keys]: {
+    source: Store<any>;
+    fn: (value: any, props: Props) => Props[K];
+  };
+};
+
+/**
+ * Computes final props type based on Props of the view component, Bind object and the keys
+ * derived via `mapProps`.
+ *
+ * Props that are "taken" by the Bind object or `mapProps` are made **optional** in the final type,
  * so it is possible to overwrite them in the component usage anyway
  */
-type FinalProps<Props, Bind extends BindFromProps<Props>> = Show<
-  Omit<Props, keyof Bind> & {
-    [K in Extract<keyof Bind, keyof Props>]?: Props[K];
+type FinalProps<
+  Props,
+  Bind extends BindFromProps<Props>,
+  MapKeys extends keyof Props,
+> = Show<
+  Omit<Props, keyof Bind | MapKeys> & {
+    [K in Extract<keyof Bind, keyof Props> | MapKeys]?: Props[K];
   }
 >;
 
@@ -66,6 +94,9 @@ type FinalProps<Props, Bind extends BindFromProps<Props>> = Show<
  *   placeholder: 'Name',
  *   onChange: (event) => nameChanged(event.target.value),
  *  },
+ *  mapProps: {
+ *   label: { source: $user, fn: (user, props) => `${props.title} ${user.name}` },
+ *  },
  * });
  * ```
  */
@@ -73,15 +104,20 @@ export function reflect<
   View extends ComponentType<any>,
   Props extends ComponentProps<View>,
   Bind extends BindFromProps<Props>,
+  MapKeys extends Exclude<keyof Props, UnbindableProps> = never,
 >(config: {
   view: View;
   bind: Bind;
+  /**
+   * Derives props for the `view` from a store value combined with the component's props.
+   */
+  mapProps?: MapPropsFromProps<Props, MapKeys>;
   hooks?: Hooks<Props>;
   /**
    * This configuration is passed directly to `useUnit`'s hook second argument.
    */
   useUnitConfig?: UseUnitConfig;
-}): FC<FinalProps<Props, Bind>>;
+}): FC<FinalProps<Props, Bind, MapKeys>>;
 
 // Note: FC is used as a return type, because tests on a real Next.js project showed,
 // that if theoretically better option like (props: ...) => React.ReactNode is used,
@@ -108,18 +144,23 @@ export function createReflect<
   View extends ComponentType<any>,
   Props extends ComponentProps<View>,
   Bind extends BindFromProps<Props>,
+  MapKeys extends Exclude<keyof Props, UnbindableProps> = never,
 >(
   component: View,
 ): (
   bind: Bind,
   features?: {
+    /**
+     * Derives props for the `view` from a store value combined with the component's props.
+     */
+    mapProps?: MapPropsFromProps<Props, MapKeys>;
     hooks?: Hooks<Props>;
     /**
      * This configuration is passed directly to `useUnit`'s hook second argument.
      */
     useUnitConfig?: UseUnitConfig;
   },
-) => FC<FinalProps<Props, Bind>>;
+) => FC<FinalProps<Props, Bind, MapKeys>>;
 
 // list types
 type PropsifyBind<Bind> = {
@@ -161,6 +202,7 @@ export function list<
         view: View;
         bind?: Bind;
         mapItem?: MapItem;
+        mapProps?: MapPropsFromProps<Props>;
         getKey?: (item: Item) => React.Key;
         hooks?: Hooks<Props>;
         /**
@@ -173,6 +215,7 @@ export function list<
         view: View;
         bind?: Bind;
         mapItem: MapItem;
+        mapProps?: MapPropsFromProps<Props>;
         getKey?: (item: Item) => React.Key;
         hooks?: Hooks<Props>;
         /**
@@ -192,10 +235,14 @@ export function list<
  * Props that are "taken" by Bind object are made **optional** in the final type,
  * so it is possible to overwrite them in the component usage anyway
  */
-type FinalPropsVariant<Props, Bind extends BindFromProps<Props>> = Show<
+type FinalPropsVariant<
+  Props,
+  Bind extends BindFromProps<Props>,
+  MapKeys extends keyof Props,
+> = Show<
   Props extends any
-    ? Omit<Props, keyof Bind> & {
-        [K in Extract<keyof Bind, keyof Props>]?: Props[K];
+    ? Omit<Props, keyof Bind | MapKeys> & {
+        [K in Extract<keyof Bind, keyof Props> | MapKeys]?: Props[K];
       }
     : never
 >;
@@ -229,6 +276,7 @@ export function variant<
   // but it is not clear why it works this way - Record<string, never> or any option other than `{}` doesn't work
   // eslint-disable-next-line @typescript-eslint/ban-types
   Bind extends BindFromProps<Props> = {},
+  MapKeys extends Exclude<keyof Props, UnbindableProps> = never,
 >(
   config:
     | {
@@ -236,6 +284,7 @@ export function variant<
         cases: Partial<Cases>;
         default?: ComponentType<Props>;
         bind?: Bind;
+        mapProps?: MapPropsFromProps<Props, MapKeys>;
         hooks?: Hooks<Props>;
         /**
          * This configuration is passed directly to `useUnit`'s hook second argument.
@@ -247,13 +296,14 @@ export function variant<
         then: ComponentType<Props>;
         else?: ComponentType<Props>;
         bind?: Bind;
+        mapProps?: MapPropsFromProps<Props, MapKeys>;
         hooks?: Hooks<Props>;
         /**
          * This configuration is passed directly to `useUnit`'s hook second argument.
          */
         useUnitConfig?: UseUnitConfig;
       },
-): FC<FinalPropsVariant<Props, Bind>>;
+): FC<FinalPropsVariant<Props, Bind, MapKeys>>;
 
 // fromTag types
 /**

--- a/public-types/reflect.d.ts
+++ b/public-types/reflect.d.ts
@@ -41,28 +41,37 @@ type BindFromProps<Props> = {
         | VoidCallback<Props[K]>;
 };
 
+type StoreValue<S> = S extends Store<infer Value> ? Value : never;
+
 /**
  * `mapProps` object type:
  * prop key -> a derived prop computed from a store value and the component's props.
  *
  * Use it to combine a store state with the incoming props to produce a prop for the `view`.
  *
- * `Keys` is captured from the actual config to know which props become overridable in the
- * final type. The `value` of `fn` is intentionally loose (`any`) - annotate it if needed -
- * while `props` is contextually typed as the view's `Props`.
+ * `Sources` is a separate generic that captures the `source` store of every entry. Because the
+ * stores are inferred independently of the `fn`s, `fn`'s `value` argument is inferred as the
+ * `source` store value (no manual annotation needed), and `props` is the view's `Props`.
+ * `fn` must return the prop type - a key that is not a prop of the view resolves to `never`.
  */
-type MapPropsFromProps<
-  Props,
-  Keys extends Exclude<keyof Props, UnbindableProps> = Exclude<
-    keyof Props,
-    UnbindableProps
-  >,
-> = {
-  [K in Keys]: {
-    source: Store<any>;
-    fn: (value: any, props: Props) => Props[K];
+type MapPropsFromSources<Props, Sources extends Record<string, Store<any>>> = {
+  [K in keyof Sources]: {
+    source: Sources[K];
+    fn: (
+      value: StoreValue<Sources[K]>,
+      props: Props,
+    ) => K extends keyof Props ? Props[K] : never;
   };
 };
+
+/**
+ * The keys of the view `Props` that are derived via `mapProps` - used to make them optional
+ * in the resulting component type.
+ */
+type MapKeysOf<Props, Sources extends Record<string, Store<any>>> = Extract<
+  keyof Sources,
+  keyof Props
+>;
 
 /**
  * Computes final props type based on Props of the view component, Bind object and the keys
@@ -104,20 +113,21 @@ export function reflect<
   View extends ComponentType<any>,
   Props extends ComponentProps<View>,
   Bind extends BindFromProps<Props>,
-  MapKeys extends Exclude<keyof Props, UnbindableProps> = never,
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  Sources extends Record<string, Store<any>> = {},
 >(config: {
   view: View;
   bind: Bind;
   /**
    * Derives props for the `view` from a store value combined with the component's props.
    */
-  mapProps?: MapPropsFromProps<Props, MapKeys>;
+  mapProps?: MapPropsFromSources<Props, Sources>;
   hooks?: Hooks<Props>;
   /**
    * This configuration is passed directly to `useUnit`'s hook second argument.
    */
   useUnitConfig?: UseUnitConfig;
-}): FC<FinalProps<Props, Bind, MapKeys>>;
+}): FC<FinalProps<Props, Bind, MapKeysOf<Props, Sources>>>;
 
 // Note: FC is used as a return type, because tests on a real Next.js project showed,
 // that if theoretically better option like (props: ...) => React.ReactNode is used,
@@ -144,7 +154,8 @@ export function createReflect<
   View extends ComponentType<any>,
   Props extends ComponentProps<View>,
   Bind extends BindFromProps<Props>,
-  MapKeys extends Exclude<keyof Props, UnbindableProps> = never,
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  Sources extends Record<string, Store<any>> = {},
 >(
   component: View,
 ): (
@@ -153,14 +164,14 @@ export function createReflect<
     /**
      * Derives props for the `view` from a store value combined with the component's props.
      */
-    mapProps?: MapPropsFromProps<Props, MapKeys>;
+    mapProps?: MapPropsFromSources<Props, Sources>;
     hooks?: Hooks<Props>;
     /**
      * This configuration is passed directly to `useUnit`'s hook second argument.
      */
     useUnitConfig?: UseUnitConfig;
   },
-) => FC<FinalProps<Props, Bind, MapKeys>>;
+) => FC<FinalProps<Props, Bind, MapKeysOf<Props, Sources>>>;
 
 // list types
 type PropsifyBind<Bind> = {
@@ -195,6 +206,8 @@ export function list<
     [M in keyof Omit<Props, keyof Bind>]: (item: Item, index: number) => Props[M];
   },
   Bind extends BindFromProps<Props> = object,
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  Sources extends Record<string, Store<any>> = {},
 >(
   config: ReflectedProps<Item, Bind> extends Props
     ? {
@@ -202,7 +215,7 @@ export function list<
         view: View;
         bind?: Bind;
         mapItem?: MapItem;
-        mapProps?: MapPropsFromProps<Props>;
+        mapProps?: MapPropsFromSources<Props, Sources>;
         getKey?: (item: Item) => React.Key;
         hooks?: Hooks<Props>;
         /**
@@ -215,7 +228,7 @@ export function list<
         view: View;
         bind?: Bind;
         mapItem: MapItem;
-        mapProps?: MapPropsFromProps<Props>;
+        mapProps?: MapPropsFromSources<Props, Sources>;
         getKey?: (item: Item) => React.Key;
         hooks?: Hooks<Props>;
         /**
@@ -276,7 +289,8 @@ export function variant<
   // but it is not clear why it works this way - Record<string, never> or any option other than `{}` doesn't work
   // eslint-disable-next-line @typescript-eslint/ban-types
   Bind extends BindFromProps<Props> = {},
-  MapKeys extends Exclude<keyof Props, UnbindableProps> = never,
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  Sources extends Record<string, Store<any>> = {},
 >(
   config:
     | {
@@ -284,7 +298,7 @@ export function variant<
         cases: Partial<Cases>;
         default?: ComponentType<Props>;
         bind?: Bind;
-        mapProps?: MapPropsFromProps<Props, MapKeys>;
+        mapProps?: MapPropsFromSources<Props, Sources>;
         hooks?: Hooks<Props>;
         /**
          * This configuration is passed directly to `useUnit`'s hook second argument.
@@ -296,14 +310,14 @@ export function variant<
         then: ComponentType<Props>;
         else?: ComponentType<Props>;
         bind?: Bind;
-        mapProps?: MapPropsFromProps<Props, MapKeys>;
+        mapProps?: MapPropsFromSources<Props, Sources>;
         hooks?: Hooks<Props>;
         /**
          * This configuration is passed directly to `useUnit`'s hook second argument.
          */
         useUnitConfig?: UseUnitConfig;
       },
-): FC<FinalPropsVariant<Props, Bind, MapKeys>>;
+): FC<FinalPropsVariant<Props, Bind, MapKeysOf<Props, Sources>>>;
 
 // fromTag types
 /**

--- a/public-types/reflect.d.ts
+++ b/public-types/reflect.d.ts
@@ -44,21 +44,44 @@ type BindFromProps<Props> = {
 type StoreValue<S> = S extends Store<infer Value> ? Value : never;
 
 /**
+ * A `source` of a `mapProps` entry: a single store, or - like `combine` / `useUnit` - an object
+ * or array of stores that are combined into a single value.
+ */
+type SourceShape =
+  | Store<any>
+  | Record<string, Store<any>>
+  | ReadonlyArray<Store<any>>;
+
+/**
+ * The value `fn` receives for a given `source` shape:
+ * - `Store<V>` -> `V`
+ * - `[Store<A>, Store<B>]` -> `[A, B]`
+ * - `{ a: Store<A>; b: Store<B> }` -> `{ a: A; b: B }`
+ */
+type SourceValue<S> = S extends Store<infer V>
+  ? V
+  : S extends ReadonlyArray<Store<any>>
+  ? { -readonly [I in keyof S]: StoreValue<S[I]> }
+  : S extends Record<string, Store<any>>
+  ? { [K in keyof S]: StoreValue<S[K]> }
+  : never;
+
+/**
  * `mapProps` object type:
  * prop key -> a derived prop computed from a store value and the component's props.
  *
  * Use it to combine a store state with the incoming props to produce a prop for the `view`.
  *
- * `Sources` is a separate generic that captures the `source` store of every entry. Because the
- * stores are inferred independently of the `fn`s, `fn`'s `value` argument is inferred as the
- * `source` store value (no manual annotation needed), and `props` is the view's `Props`.
+ * `Sources` is a separate generic that captures the `source` of every entry. Because the
+ * sources are inferred independently of the `fn`s, `fn`'s `value` argument is inferred as the
+ * resolved source value (no manual annotation needed), and `props` is the view's `Props`.
  * `fn` must return the prop type - a key that is not a prop of the view resolves to `never`.
  */
-type MapPropsFromSources<Props, Sources extends Record<string, Store<any>>> = {
+type MapPropsFromSources<Props, Sources extends Record<string, SourceShape>> = {
   [K in keyof Sources]: {
     source: Sources[K];
     fn: (
-      value: StoreValue<Sources[K]>,
+      value: SourceValue<Sources[K]>,
       props: Props,
     ) => K extends keyof Props ? Props[K] : never;
   };
@@ -68,7 +91,7 @@ type MapPropsFromSources<Props, Sources extends Record<string, Store<any>>> = {
  * The keys of the view `Props` that are derived via `mapProps` - used to make them optional
  * in the resulting component type.
  */
-type MapKeysOf<Props, Sources extends Record<string, Store<any>>> = Extract<
+type MapKeysOf<Props, Sources extends Record<string, SourceShape>> = Extract<
   keyof Sources,
   keyof Props
 >;
@@ -114,7 +137,7 @@ export function reflect<
   Props extends ComponentProps<View>,
   Bind extends BindFromProps<Props>,
   // eslint-disable-next-line @typescript-eslint/ban-types
-  Sources extends Record<string, Store<any>> = {},
+  Sources extends Record<string, SourceShape> = {},
 >(config: {
   view: View;
   bind: Bind;
@@ -155,7 +178,7 @@ export function createReflect<
   Props extends ComponentProps<View>,
   Bind extends BindFromProps<Props>,
   // eslint-disable-next-line @typescript-eslint/ban-types
-  Sources extends Record<string, Store<any>> = {},
+  Sources extends Record<string, SourceShape> = {},
 >(
   component: View,
 ): (
@@ -207,7 +230,7 @@ export function list<
   },
   Bind extends BindFromProps<Props> = object,
   // eslint-disable-next-line @typescript-eslint/ban-types
-  Sources extends Record<string, Store<any>> = {},
+  Sources extends Record<string, SourceShape> = {},
 >(
   config: ReflectedProps<Item, Bind> extends Props
     ? {
@@ -290,7 +313,7 @@ export function variant<
   // eslint-disable-next-line @typescript-eslint/ban-types
   Bind extends BindFromProps<Props> = {},
   // eslint-disable-next-line @typescript-eslint/ban-types
-  Sources extends Record<string, Store<any>> = {},
+  Sources extends Record<string, SourceShape> = {},
 >(
   config:
     | {

--- a/src/core/list.ts
+++ b/src/core/list.ts
@@ -3,7 +3,14 @@ import { useProvidedScope } from 'effector-react';
 import React from 'react';
 
 import { reflectFactory } from './reflect';
-import { BindProps, Context, Hooks, UseUnitConifg, View } from './types';
+import {
+  BindProps,
+  Context,
+  Hooks,
+  MapPropsConfig,
+  UseUnitConifg,
+  View,
+} from './types';
 
 export function listFactory(context: Context) {
   const reflect = reflectFactory(context);
@@ -21,12 +28,14 @@ export function listFactory(context: Context) {
     };
     getKey?: (item: Item) => React.Key;
     hooks?: Hooks<Props>;
+    mapProps?: MapPropsConfig<Props>;
     useUnitConfig?: UseUnitConifg;
   }): React.FC {
     const ItemView = reflect<Props, Bind>({
       view: config.view,
       bind: config.bind ? config.bind : ({} as Bind),
       hooks: config.hooks,
+      mapProps: config.mapProps,
       useUnitConfig: config.useUnitConfig,
     });
 

--- a/src/core/reflect.ts
+++ b/src/core/reflect.ts
@@ -2,11 +2,19 @@ import { Effect, Event, is, scopeBind, Store } from 'effector';
 import { useProvidedScope } from 'effector-react';
 import React, { PropsWithoutRef, RefAttributes } from 'react';
 
-import { BindProps, Context, Hooks, UseUnitConifg, View } from './types';
+import {
+  BindProps,
+  Context,
+  Hooks,
+  MapPropsConfig,
+  UseUnitConifg,
+  View,
+} from './types';
 
 export interface ReflectConfig<Props, Bind extends BindProps<Props>> {
   view: View<Props>;
   bind: Bind;
+  mapProps?: MapPropsConfig<Props>;
   hooks?: Hooks<Props>;
   useUnitConfig?: UseUnitConifg;
 }
@@ -17,7 +25,10 @@ export function reflectCreateFactory(context: Context) {
   return function createReflect<Props>(view: View<Props>) {
     return <Bind extends BindProps<Props> = BindProps<Props>>(
       bind: Bind,
-      params?: Pick<ReflectConfig<Props, Bind>, 'hooks' | 'useUnitConfig'>,
+      params?: Pick<
+        ReflectConfig<Props, Bind>,
+        'hooks' | 'useUnitConfig' | 'mapProps'
+      >,
     ) => reflect<Props, Bind>({ view, bind, ...params });
   };
 }
@@ -29,15 +40,47 @@ export function reflectFactory(context: Context) {
     const { stores, events, data, functions } = sortProps(config.bind);
     const hooks = sortProps(config.hooks || {});
 
+    const mapProps = config.mapProps ?? {};
+    const mapPropsKeys = Object.keys(mapProps);
+    const mapPropsSources: Record<string, Store<unknown>> = {};
+    for (const key of mapPropsKeys) {
+      mapPropsSources[key] = (mapProps as any)[key].source;
+    }
+
     return React.forwardRef((props: Props, ref) => {
       const storeProps = context.useUnit(stores, config.useUnitConfig);
       const eventsProps = context.useUnit(events as any, config.useUnitConfig);
       const functionProps = useBoundFunctions(functions);
+      const mapPropsValues = context.useUnit(
+        mapPropsSources as any,
+        config.useUnitConfig,
+      );
 
       const finalProps: any = {};
 
       if (ref) {
         finalProps.ref = ref;
+      }
+
+      const mappedProps: Record<string, unknown> = {};
+      if (mapPropsKeys.length > 0) {
+        // props passed to the `fn` should already include the bound values,
+        // so it is possible to derive a prop from both a store and other props
+        const propsForFn = Object.assign(
+          {},
+          storeProps,
+          eventsProps,
+          data,
+          functionProps,
+          props,
+        );
+
+        for (const key of mapPropsKeys) {
+          mappedProps[key] = (mapProps as any)[key].fn(
+            (mapPropsValues as any)[key],
+            propsForFn,
+          );
+        }
       }
 
       const elementProps: Props = Object.assign(
@@ -46,6 +89,7 @@ export function reflectFactory(context: Context) {
         eventsProps,
         data,
         functionProps,
+        mappedProps,
         props,
       );
 

--- a/src/core/reflect.ts
+++ b/src/core/reflect.ts
@@ -1,4 +1,4 @@
-import { Effect, Event, is, scopeBind, Store } from 'effector';
+import { combine, Effect, Event, is, scopeBind, Store } from 'effector';
 import { useProvidedScope } from 'effector-react';
 import React, { PropsWithoutRef, RefAttributes } from 'react';
 
@@ -44,7 +44,10 @@ export function reflectFactory(context: Context) {
     const mapPropsKeys = Object.keys(mapProps);
     const mapPropsSources: Record<string, Store<unknown>> = {};
     for (const key of mapPropsKeys) {
-      mapPropsSources[key] = (mapProps as any)[key].source;
+      const source = (mapProps as any)[key].source;
+      // `source` can be a single store or - like `combine`/`useUnit` - an object
+      // or array of stores; normalize it to a single store once, at creation time.
+      mapPropsSources[key] = is.store(source) ? source : combine(source);
     }
 
     return React.forwardRef((props: Props, ref) => {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -20,9 +20,14 @@ export type BindProps<Props> = {
   [K in keyof Props]: Props[K] | Store<Props[K]> | EventCallable<void>;
 };
 
+export type MapPropsSource =
+  | Store<any>
+  | Record<string, Store<any>>
+  | ReadonlyArray<Store<any>>;
+
 export type MapPropsConfig<Props> = {
   [K in keyof Props]?: {
-    source: Store<any>;
+    source: MapPropsSource;
     fn: (value: any, props: Props) => Props[K];
   };
 };

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -20,6 +20,13 @@ export type BindProps<Props> = {
   [K in keyof Props]: Props[K] | Store<Props[K]> | EventCallable<void>;
 };
 
+export type MapPropsConfig<Props> = {
+  [K in keyof Props]?: {
+    source: Store<any>;
+    fn: (value: any, props: Props) => Props[K];
+  };
+};
+
 export type Hook<Props> =
   | ((props: Props) => any)
   | EventCallable<Props>

--- a/src/core/variant.ts
+++ b/src/core/variant.ts
@@ -2,7 +2,14 @@ import { Store } from 'effector';
 import React from 'react';
 
 import { reflectFactory } from './reflect';
-import { BindProps, Context, Hooks, UseUnitConifg, View } from './types';
+import {
+  BindProps,
+  Context,
+  Hooks,
+  MapPropsConfig,
+  UseUnitConifg,
+  View,
+} from './types';
 
 const Default = () => null;
 
@@ -21,6 +28,7 @@ export function variantFactory(context: Context) {
           cases: Record<Variant, View<Props>>;
           hooks?: Hooks<Props>;
           default?: View<Props>;
+          mapProps?: MapPropsConfig<Props>;
           useUnitConfig?: UseUnitConifg;
         }
       | {
@@ -29,6 +37,7 @@ export function variantFactory(context: Context) {
           else?: View<Props>;
           hooks?: Hooks<Props>;
           bind?: Bind;
+          mapProps?: MapPropsConfig<Props>;
           useUnitConfig?: UseUnitConifg;
         },
   ): (p: Props) => React.ReactNode {
@@ -70,6 +79,7 @@ export function variantFactory(context: Context) {
       bind,
       view: View,
       hooks: config.hooks,
+      mapProps: config.mapProps,
       useUnitConfig: config.useUnitConfig,
     }) as unknown as (p: Props) => React.ReactNode;
   };

--- a/src/no-ssr/reflect.test.tsx
+++ b/src/no-ssr/reflect.test.tsx
@@ -647,6 +647,50 @@ describe('mapProps', () => {
     const container = render(<Hello testId="hello" label="overridden" />);
     expect(container.getByTestId('hello').textContent).toBe('overridden');
   });
+
+  test('combines an object of stores as source', async () => {
+    const setName = createEvent<string>();
+    const $name = restore(setName, 'Bob');
+    const $count = createStore(2);
+
+    const Hello = reflect({
+      view: Greeting,
+      bind: {},
+      mapProps: {
+        label: {
+          source: { name: $name, count: $count },
+          fn: (s) => `${s.name} (${s.count})`,
+        },
+      },
+    });
+
+    const container = render(<Hello testId="hello" greeting="" />);
+    expect(container.getByTestId('hello').textContent).toBe('Bob (2)');
+
+    await act(async () => {
+      setName('Alice');
+    });
+    expect(container.getByTestId('hello').textContent).toBe('Alice (2)');
+  });
+
+  test('combines an array of stores as source', () => {
+    const $a = createStore('a');
+    const $b = createStore('b');
+
+    const Hello = reflect({
+      view: Greeting,
+      bind: {},
+      mapProps: {
+        label: {
+          source: [$a, $b],
+          fn: ([a, b]) => `${a}-${b}`,
+        },
+      },
+    });
+
+    const container = render(<Hello testId="hello" greeting="" />);
+    expect(container.getByTestId('hello').textContent).toBe('a-b');
+  });
 });
 
 describe('useUnitConfig', () => {

--- a/src/no-ssr/reflect.test.tsx
+++ b/src/no-ssr/reflect.test.tsx
@@ -601,6 +601,54 @@ describe('fromTag helper', () => {
   });
 });
 
+describe('mapProps', () => {
+  const Greeting: FC<{ testId: string; label: string }> = (props) => {
+    return <span data-testid={props.testId}>{props.label}</span>;
+  };
+
+  test('derives a prop from a store value combined with props', async () => {
+    const setName = createEvent<string>();
+    const $name = restore(setName, 'Bob');
+
+    const Hello = reflect({
+      view: Greeting,
+      bind: {},
+      mapProps: {
+        label: {
+          source: $name,
+          fn: (name, props: { greeting: string }) => `${props.greeting}, ${name}!`,
+        },
+      },
+    });
+
+    const container = render(<Hello testId="hello" greeting="Hi" />);
+    expect(container.getByTestId('hello').textContent).toBe('Hi, Bob!');
+
+    await act(async () => {
+      setName('Alice');
+    });
+    expect(container.getByTestId('hello').textContent).toBe('Hi, Alice!');
+  });
+
+  test('explicitly passed prop wins over the derived one', () => {
+    const $name = createStore('Bob');
+
+    const Hello = reflect({
+      view: Greeting,
+      bind: {},
+      mapProps: {
+        label: {
+          source: $name,
+          fn: (name) => `Hello, ${name}!`,
+        },
+      },
+    });
+
+    const container = render(<Hello testId="hello" label="overridden" />);
+    expect(container.getByTestId('hello').textContent).toBe('overridden');
+  });
+});
+
 describe('useUnitConfig', () => {
   test('useUnit config should be passed to underlying useUnit', () => {
     expect(() => {

--- a/src/ssr/reflect.test.tsx
+++ b/src/ssr/reflect.test.tsx
@@ -259,3 +259,37 @@ test('use only event for bind', async () => {
   expect(name.value).toBe('');
   expect(age.value).toBe('');
 });
+
+test('mapProps derives a prop from a scoped store and props', async () => {
+  const app = createDomain();
+
+  const setName = app.createEvent<string>();
+  const $name = restore(setName, 'Bob');
+
+  const Greeting: FC<{ testId: string; label: string }> = (props) => {
+    return <span data-testid={props.testId}>{props.label}</span>;
+  };
+
+  const Hello = reflect({
+    view: Greeting,
+    bind: {},
+    mapProps: {
+      label: {
+        source: $name,
+        fn: (name, props: { greeting: string }) => `${props.greeting}, ${name}!`,
+      },
+    },
+  });
+
+  const scope = fork(app, { values: [[$name, 'Alice']] });
+
+  const container = render(
+    <Provider value={scope}>
+      <Hello testId="hello" greeting="Hi" />
+    </Provider>,
+  );
+
+  expect(container.getByTestId('hello').textContent).toBe('Hi, Alice!');
+  // global store is untouched
+  expect($name.getState()).toBe('Bob');
+});

--- a/type-tests/types-reflect.tsx
+++ b/type-tests/types-reflect.tsx
@@ -579,22 +579,23 @@ function localize(value: string): unknown {
   });
 }
 
-// mapProps: derives a prop from a store value combined with props
+// mapProps: derives a prop from a store value combined with props,
+// `value` is inferred from `source`, `props` is the view's props
 {
   const Greeting: React.FC<{
     label: string;
     greeting: string;
   }> = () => null;
-  const $name = createStore<string>('');
+  const $user = createStore<{ name: string }>({ name: '' });
 
   const ReflectedGreeting = reflect({
     view: Greeting,
     bind: {},
     mapProps: {
       label: {
-        source: $name,
-        // `props` is contextually typed as the view's Props
-        fn: (name, props) => `${props.greeting} ${name}`,
+        source: $user,
+        // `user` is inferred as { name: string }, `props` as the view's Props
+        fn: (user, props) => `${props.greeting} ${user.name}`,
       },
     },
   });
@@ -612,6 +613,26 @@ function localize(value: string): unknown {
   expectType<React.FC>(AppOverride);
 }
 
+// mapProps: `value` is inferred from `source` - accessing a missing field errors
+{
+  const Greeting: React.FC<{
+    label: string;
+  }> = () => null;
+  const $user = createStore<{ name: string }>({ name: '' });
+
+  reflect({
+    view: Greeting,
+    bind: {},
+    mapProps: {
+      label: {
+        source: $user,
+        // @ts-expect-error - `nope` does not exist on the inferred source value
+        fn: (user) => `${user.nope}`,
+      },
+    },
+  });
+}
+
 // mapProps: fn return type must match the prop type
 {
   const Greeting: React.FC<{
@@ -626,7 +647,7 @@ function localize(value: string): unknown {
       label: {
         source: $count,
         // @ts-expect-error - number is not assignable to the string `label` prop
-        fn: () => 42,
+        fn: (count) => count,
       },
     },
   });
@@ -635,7 +656,7 @@ function localize(value: string): unknown {
   expectType<React.FC>(App);
 }
 
-// mapProps: should not allow keys that are not props of the view
+// mapProps: a key that is not a prop of the view makes fn's return type `never`
 {
   const Greeting: React.FC<{
     label: string;
@@ -646,10 +667,10 @@ function localize(value: string): unknown {
     view: Greeting,
     bind: {},
     mapProps: {
-      // @ts-expect-error - `unknownProp` is not a prop of the view
       unknownProp: {
         source: $name,
-        fn: (value: string) => value,
+        // @ts-expect-error - `unknownProp` is not a prop, so the return type is `never`
+        fn: (value) => value,
       },
     },
   });

--- a/type-tests/types-reflect.tsx
+++ b/type-tests/types-reflect.tsx
@@ -578,3 +578,82 @@ function localize(value: string): unknown {
     },
   });
 }
+
+// mapProps: derives a prop from a store value combined with props
+{
+  const Greeting: React.FC<{
+    label: string;
+    greeting: string;
+  }> = () => null;
+  const $name = createStore<string>('');
+
+  const ReflectedGreeting = reflect({
+    view: Greeting,
+    bind: {},
+    mapProps: {
+      label: {
+        source: $name,
+        // `props` is contextually typed as the view's Props
+        fn: (name, props) => `${props.greeting} ${name}`,
+      },
+    },
+  });
+
+  // `greeting` is still required, `label` is made optional by mapProps
+  const App: React.FC = () => {
+    return <ReflectedGreeting greeting="Hi" />;
+  };
+  expectType<React.FC>(App);
+
+  // the derived prop can still be overridden at the usage site
+  const AppOverride: React.FC = () => {
+    return <ReflectedGreeting greeting="Hi" label="overridden" />;
+  };
+  expectType<React.FC>(AppOverride);
+}
+
+// mapProps: fn return type must match the prop type
+{
+  const Greeting: React.FC<{
+    label: string;
+  }> = () => null;
+  const $count = createStore<number>(0);
+
+  const ReflectedGreeting = reflect({
+    view: Greeting,
+    bind: {},
+    mapProps: {
+      label: {
+        source: $count,
+        // @ts-expect-error - number is not assignable to the string `label` prop
+        fn: () => 42,
+      },
+    },
+  });
+
+  const App: React.FC = () => <ReflectedGreeting />;
+  expectType<React.FC>(App);
+}
+
+// mapProps: should not allow keys that are not props of the view
+{
+  const Greeting: React.FC<{
+    label: string;
+  }> = () => null;
+  const $name = createStore<string>('');
+
+  const ReflectedGreeting = reflect({
+    view: Greeting,
+    bind: {},
+    mapProps: {
+      // @ts-expect-error - `unknownProp` is not a prop of the view
+      unknownProp: {
+        source: $name,
+        fn: (value: string) => value,
+      },
+    },
+  });
+
+  const App: React.FC = () => <ReflectedGreeting label="x" />;
+  expectType<React.FC>(App);
+}

--- a/type-tests/types-reflect.tsx
+++ b/type-tests/types-reflect.tsx
@@ -678,3 +678,72 @@ function localize(value: string): unknown {
   const App: React.FC = () => <ReflectedGreeting label="x" />;
   expectType<React.FC>(App);
 }
+
+// mapProps: `source` can be an object of stores - value is the resolved shape
+{
+  const Greeting: React.FC<{
+    label: string;
+    currency: string;
+  }> = () => null;
+  const $cart = createStore<{ count: number }>({ count: 0 });
+  const $name = createStore<string>('');
+
+  const ReflectedGreeting = reflect({
+    view: Greeting,
+    bind: {},
+    mapProps: {
+      label: {
+        source: { cart: $cart, name: $name },
+        // value inferred as { cart: { count: number }; name: string }
+        fn: (s, props) => `${s.name}: ${s.cart.count} ${props.currency}`,
+      },
+    },
+  });
+
+  const App: React.FC = () => <ReflectedGreeting currency="₽" />;
+  expectType<React.FC>(App);
+}
+
+// mapProps: object `source` - accessing a missing field errors
+{
+  const Greeting: React.FC<{
+    label: string;
+  }> = () => null;
+  const $cart = createStore<{ count: number }>({ count: 0 });
+
+  reflect({
+    view: Greeting,
+    bind: {},
+    mapProps: {
+      label: {
+        source: { cart: $cart },
+        // @ts-expect-error - `nope` is not in the resolved source shape
+        fn: (s) => `${s.nope}`,
+      },
+    },
+  });
+}
+
+// mapProps: `source` can be an array of stores - value is the resolved tuple
+{
+  const Greeting: React.FC<{
+    label: string;
+  }> = () => null;
+  const $a = createStore<number>(0);
+  const $b = createStore<string>('');
+
+  const ReflectedGreeting = reflect({
+    view: Greeting,
+    bind: {},
+    mapProps: {
+      label: {
+        source: [$a, $b] as const,
+        // value inferred as [number, string]
+        fn: ([a, b]) => `${a} ${b}`,
+      },
+    },
+  });
+
+  const App: React.FC = () => <ReflectedGreeting />;
+  expectType<React.FC>(App);
+}


### PR DESCRIPTION
Closes https://github.com/effector/reflect/issues/13

Adds an optional `mapProps` field to `reflect` (and `createReflect`, `variant`, `list`) that computes a prop for the view from a store value combined with the component's own props:

    reflect({
      view: A,
      bind: { foo: $data },
      mapProps: {
        bar: { source: $data, fn: (data, props) => data[props.key] },
      },
    })

- `source` is read reactively via useUnit, so the component re-renders only when that store changes
- `fn` receives the store value and the props (bound + incoming)
- derived props are made optional in the resulting component type and can still be overridden explicitly at the usage site (external props win)

Covered by runtime tests (no-ssr + ssr/scope), type tests and docs.

Example:

```tsx
import { reflect } from '@effector/reflect';
import { Badge, Group, Text } from '@mantine/core';
import { IconShoppingCart } from '@tabler/icons-react';
import { combine } from 'effector';

import { CartModel } from '@/entities/Cart';

interface CartSummaryViewProps {
    /** Incoming prop — a static label set at the usage site. */
    label: string;
    /** Incoming prop — currency suffix set at the usage site. */
    currency: string;
    /** Bound from the store via `bind`. */
    count: number;
    /** Derived from store state + props via `mapProps` (optional at the usage site). */
    summary: string;
}

const CartSummaryView = ({ count, summary }: CartSummaryViewProps) => (
    <Group gap='xs' align='center'>
        <IconShoppingCart size={18} />
        <Text fw={600}>{summary}</Text>
        <Badge color={count > 0 ? 'yellow' : 'gray'} c='black'>
            {count}
        </Badge>
    </Group>
);

/**
 * `source` for `mapProps` is a single store (or object-shaped if needed), so we `combine` the two cart stores
 * we need into one shape store first.
 */
const $cartSummarySource = combine(CartModel.$cartProductsCount, CartModel.$cartTotalFinalPrice, (count, total) => ({
    count,
    total,
}));

/**
 * Example of `@effector/reflect`'s `mapProps`:
 * a prop (`summary`) is derived from store state (`source`) combined with the
 * component's own props (`label`, `currency`).
 *
 * The component re-renders only when `$cartSummarySource` changes.
 */
export const CartSummary = reflect({
    view: CartSummaryView,
    bind: {
        // plain reactive binding — `count` follows the store
        count: CartModel.$cartProductsCount,
    },
    mapProps: {
        summary: {
            source: $cartSummarySource,
            // `cart` is the `source` value (typed not loosely as `any`, so we not necessary to annotate it),
            // `props` are the component's props — contextually typed as the view's props.
            fn: (cart, props) =>
                `${props.label}: ${cart.count} шт. на ${cart.total.toLocaleString('ru-RU')} ${props.currency}`,
        },
    },
});

```