### PR TITLE
fix(build): restore exports field in dist/package.json

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -37,7 +37,7 @@ await measure(`package.json → ./dist/package.json`, `created in`, async () => 
     maintainers: Existing.maintainers,
     license: Existing.license,
     publishConfig: Existing.publishConfig,
-    export: Existing.export,
+    exports: Existing.exports,
     main: Existing.main,
     module: Existing.module,
     typings: Existing.typings,

--- a/validate_dist.mjs
+++ b/validate_dist.mjs
@@ -14,3 +14,25 @@ console.log();
 try {
   const publintResult = await $`pnpm publint ${pkgDir}`;
 } catch (error) {}
+
+// Guard against regressions in dist/package.json generation (see build.mjs):
+// a missing `exports` field makes bundlers resolve the CJS build, which breaks
+// the `@effector/reflect/scope` subpath and causes a dual-package hazard with
+// effector-react (scope is lost inside `variant`/`reflect`).
+{
+  const distPkg = JSON.parse(
+    await fs.readFile(resolve(pkgDir, 'package.json'), { encoding: 'utf-8' }),
+  );
+  const missing = [];
+  if (!distPkg.exports) missing.push('exports');
+  else {
+    if (!distPkg.exports['.']) missing.push("exports['.']");
+    if (!distPkg.exports['./scope']) missing.push("exports['./scope']");
+  }
+  if (missing.length > 0) {
+    throw new Error(
+      `dist/package.json is missing required field(s): ${missing.join(', ')}`,
+    );
+  }
+  console.log('✓ dist/package.json has valid "exports"');
+}


### PR DESCRIPTION
## Problem

`build.mjs` generates `dist/package.json` from a whitelist of fields, but uses a typo `export: Existing.export` (singular, non-existent) instead of `exports: Existing.exports` (introduced in cef40e6). As a result the published 10.1.0 package has **no `exports` field**.

## Impact

- The `@effector/reflect/scope` subpath no longer resolves.
- Bundlers fall back to `main` (CJS). The CJS entry `require`s its own copy of `effector-react`, causing a **dual-package hazard**: `<Provider>` (ESM) and `useUnit` inside `variant`/`reflect` (CJS) reference different effector-react instances, so the forked scope is lost — `variant` reads the store default instead of the scoped value.

Reproduced in a React 19 app: `variant({ if: $store, then, else })` under `<Provider value={fork(...)}>` rendered the `then` branch even though the scoped value was `false`. Pinning back to 10.0.2 (which still shipped `exports`) fixed it.

## Fix

- `build.mjs`: `export` → `exports`.
- `validate_dist.mjs`: fail when the generated `dist/package.json` is missing the `exports` field (`.` / `./scope`). The existing `attw`/`publint` calls swallow their errors, so the regression went unnoticed.

## Verify

`pnpm build` now emits `dist/package.json` with the full `exports` map (both `.` and `./scope` conditions).

Closes #104
